### PR TITLE
фикс запуска под windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,2 @@
 *.sh eol=lf
-configs/client-vnc/rootfs/etc/services.d/onec/run eol=lf
-configs/client-vnc/rootfs/etc/services.d/x11vnc/run eol=lf
-configs/client-vnc/rootfs/etc/services.d/xfce/run eol=lf
-configs/client-vnc/rootfs/etc/services.d/xvfb/run eol=lf
+configs/client-vnc/rootfs/etc/** eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 *.sh eol=lf
+configs/client-vnc/rootfs/etc/services.d/onec/run eol=lf
+configs/client-vnc/rootfs/etc/services.d/x11vnc/run eol=lf
+configs/client-vnc/rootfs/etc/services.d/xfce/run eol=lf
+configs/client-vnc/rootfs/etc/services.d/xvfb/run eol=lf


### PR DESCRIPTION
В Windows по умолчанию файлы конфига конвертятся в CRLF, что потом ломает запуск сервисов