### PR TITLE
Ошибка сборки образа. Не доступен keyserver

### DIFF
--- a/client-vnc/Dockerfile
+++ b/client-vnc/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update \
       procps \
       x11vnc \
   # Install libpng12-0 from xenial
-  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5 \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 40976EAF437D05B5 \
   && echo "deb http://security.ubuntu.com/ubuntu xenial-security main" > /etc/apt/sources.list.d/xenial-security.list \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Без явного указания протокола и порта получаем ошибку: gpg: keyserver receive failed: No keyserver available