### PR TITLE
Изменен client-vnc/Dockerfile, исправлена ошибка сборки образа

### DIFF
--- a/client-vnc/Dockerfile
+++ b/client-vnc/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update \
   && rm -rf  /etc/apt/sources.list.d/xenial-security.list \
   && apt-get update \
   # Install libwebkitgtk from stretch
-  && echo "deb http://deb.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list.d/stretch.list \
+  && echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list.d/stretch.list \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     libwebkitgtk-3.0-0 \


### PR DESCRIPTION
* исправлена сборка образа в связи с переездом репозитория debian stretch в архив
* [информационное письмо](https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html) о смене местоположения репозитория 