### PR TITLE
Изменил OpenJDK на Temurin

### DIFF
--- a/jdk/Dockerfile
+++ b/jdk/Dockerfile
@@ -7,7 +7,7 @@ FROM ${DOCKER_USERNAME}/${BASE_IMAGE}:${BASE_TAG}
 LABEL maintainer="Nikita Gryzlov <NikGryzlov@1bit.com>, FirstBit"
 
 # Install OpenJDK
-ARG OPENJDK_VERSION=15
+ARG TEMURINJDK_VERSION=17
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -19,18 +19,11 @@ RUN apt-get update \
       locales \
       software-properties-common \
       wget \
-  && wget https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public -O adoptopenjdk.gpg.public \
-  && gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --import adoptopenjdk.gpg.public \
-  && gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --export --output adoptopenjdk-archive-keyring.gpg \
-  && rm adoptopenjdk-keyring.gpg adoptopenjdk.gpg.public \
-  && mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings \
-  && chown root:root /usr/share/keyrings/adoptopenjdk-archive-keyring.gpg \
-  && echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb bullseye main" | tee /etc/apt/sources.list.d/adoptopenjdk.list \
-  && apt-get update \
-  # see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199#23
-  && mkdir -p /usr/share/man/man1 \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      adoptopenjdk-${OPENJDK_VERSION}-hotspot \
+  && && mkdir -p /etc/apt/keyrings \
+  && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
+  && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
+  && apt update \
+  && apt install -y temurin-${TEMURINJDK_VERSION}-jdk \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 
 # remove DST Root CA X3 cert if it exists

--- a/jdk/Dockerfile
+++ b/jdk/Dockerfile
@@ -7,7 +7,7 @@ FROM ${DOCKER_USERNAME}/${BASE_IMAGE}:${BASE_TAG}
 LABEL maintainer="Nikita Gryzlov <NikGryzlov@1bit.com>, FirstBit"
 
 # Install OpenJDK
-ARG TEMURINJDK_VERSION=17
+ARG OPENJDK_VERSION=17
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/jdk/Dockerfile
+++ b/jdk/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
   && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
   && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
   && apt update \
-  && apt install -y temurin-${TEMURINJDK_VERSION}-jdk \
+  && apt install -y temurin-${OPENJDK_VERSION}-jdk \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 
 # remove DST Root CA X3 cert if it exists

--- a/jdk/Dockerfile
+++ b/jdk/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
       locales \
       software-properties-common \
       wget \
-  && && mkdir -p /etc/apt/keyrings \
+  && mkdir -p /etc/apt/keyrings \
   && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
   && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
   && apt update \


### PR DESCRIPTION
[Ссылка на ишуз](https://github.com/firstBitMarksistskaya/onec-docker/issues/28)

Там протух репо с openjdk. заменил его на temurin