### PR TITLE
Поддержка 1cedtcli и переход на базовый образ с JDK 17 для EDT 2024.1.0+

### DIFF
--- a/build-edt-k8s-agent.sh
+++ b/build-edt-k8s-agent.sh
@@ -17,7 +17,7 @@ fi
 #Если версия EDT >= 2024.1.0, использовать JDK 17
 if [[ "$(printf "%s\n" "$EDT_VERSION" "2024" | sort -V | head -n 1)" == "2024" ]]; then
   BASE_IMAGE="azul/zulu-openjdk"
-  BASE_TAG="17.0.13-jdk"
+  BASE_TAG="17"
 else
   BASE_IMAGE="eclipse-temurin"
   BASE_TAG="11"

--- a/build-edt-k8s-agent.sh
+++ b/build-edt-k8s-agent.sh
@@ -14,6 +14,15 @@ if [ "${DOCKER_SYSTEM_PRUNE}" = 'true' ] ; then
     docker system prune -af
 fi
 
+#Если версия EDT >= 2024.1.0, использовать JDK 17
+if [[ "$(printf "%s\n" "$EDT_VERSION" "2024" | sort -V | head -n 1)" == "2024" ]]; then
+  BASE_IMAGE="azul/zulu-openjdk"
+  BASE_TAG="17.0.13-jdk"
+else
+  BASE_IMAGE="eclipse-temurin"
+  BASE_TAG="11"
+fi
+
 last_arg='.'
 if [ "${NO_CACHE}" = 'true' ] ; then
     last_arg='--no-cache .'
@@ -37,6 +46,8 @@ docker build \
     --build-arg ONEC_USERNAME=$ONEC_USERNAME \
     --build-arg ONEC_PASSWORD=$ONEC_PASSWORD \
     --build-arg EDT_VERSION="$EDT_VERSION" \
+    --build-arg BASE_IMAGE=$BASE_IMAGE \
+    --build-arg BASE_TAG=$BASE_TAG \
     --build-arg DOWNLOADER_REGISTRY_URL=$DOCKER_REGISTRY_URL \
     --build-arg DOWNLOADER_IMAGE=oscript-downloader \
     --build-arg DOWNLOADER_TAG=latest \

--- a/build-edt-swarm-agent.bat
+++ b/build-edt-swarm-agent.bat
@@ -8,11 +8,21 @@ if %DOCKER_SYSTEM_PRUNE%=="true" docker system prune -af
 
 if %ERRORLEVEL% neq 0 goto end
 
+for /f "delims=." %%a in ("%EDT_VERSION%") do set EDT_MAJOR_VERSION=%aa
+if %EDT_MAJOR_VERSION% GEQ "2024" (
+  set BASE_IMAGE="azul/zulu-openjdk"
+  set BASE_TAG="17.0.13-jdk"
+) else (
+  set BASE_IMAGE="eclipse-temurin"
+  set BASE_TAG="11"
+)
+
+if %ERRORLEVEL% neq 0 goto end
+
 if %NO_CACHE%=="true" (SET last_arg="--no-cache .") else (SET last_arg=".")
 
 set edt_version=%EDT_VERSION%
 set edt_escaped=%edt_version: =_%
-
 
 docker build ^
 	--pull ^
@@ -28,6 +38,8 @@ docker build ^
 	--build-arg ONEC_USERNAME=%ONEC_USERNAME% ^
 	--build-arg ONEC_PASSWORD=%ONEC_PASSWORD% ^
     --build-arg EDT_VERSION=%EDT_VERSION% ^
+    --build-arg BASE_IMAGE=%BASE_IMAGE% ^
+    --build-arg BASE_TAG=%BASE_TAG% ^
     --build-arg DOCKER_REGISTRY_URL=%DOCKER_REGISTRY_URL% ^
     --build-arg DOWNLOADER_IMAGE=oscript-downloader ^
     --build-arg DOWNLOADER_TAG=latest ^

--- a/build-edt-swarm-agent.bat
+++ b/build-edt-swarm-agent.bat
@@ -11,7 +11,7 @@ if %ERRORLEVEL% neq 0 goto end
 for /f "delims=." %%a in ("%EDT_VERSION%") do set EDT_MAJOR_VERSION=%aa
 if %EDT_MAJOR_VERSION% GEQ "2024" (
   set BASE_IMAGE="azul/zulu-openjdk"
-  set BASE_TAG="17.0.13-jdk"
+  set BASE_TAG="17"
 ) else (
   set BASE_IMAGE="eclipse-temurin"
   set BASE_TAG="11"

--- a/build-edt-swarm-agent.sh
+++ b/build-edt-swarm-agent.sh
@@ -17,7 +17,7 @@ fi
 #Если версия EDT >= 2024.1.0, использовать JDK 17
 if [[ "$(printf "%s\n" "$EDT_VERSION" "2024" | sort -V | head -n 1)" == "2024" ]]; then
   BASE_IMAGE="azul/zulu-openjdk"
-  BASE_TAG="17.0.13-jdk"
+  BASE_TAG="17"
 else
   BASE_IMAGE="eclipse-temurin"
   BASE_TAG="11"

--- a/build-edt-swarm-agent.sh
+++ b/build-edt-swarm-agent.sh
@@ -14,6 +14,15 @@ if [ "${DOCKER_SYSTEM_PRUNE}" = 'true' ] ; then
     docker system prune -af
 fi
 
+#Если версия EDT >= 2024.1.0, использовать JDK 17
+if [[ "$(printf "%s\n" "$EDT_VERSION" "2024" | sort -V | head -n 1)" == "2024" ]]; then
+  BASE_IMAGE="azul/zulu-openjdk"
+  BASE_TAG="17.0.13-jdk"
+else
+  BASE_IMAGE="eclipse-temurin"
+  BASE_TAG="11"
+fi
+
 last_arg='.'
 if [ "${NO_CACHE}" = 'true' ] ; then
     last_arg='--no-cache .'
@@ -37,6 +46,8 @@ docker build \
     --build-arg ONEC_USERNAME=$ONEC_USERNAME \
     --build-arg ONEC_PASSWORD=$ONEC_PASSWORD \
     --build-arg EDT_VERSION="$EDT_VERSION" \
+    --build-arg BASE_IMAGE=$BASE_IMAGE \
+    --build-arg BASE_TAG=$BASE_TAG \
     --build-arg DOWNLOADER_REGISTRY_URL=$DOCKER_REGISTRY_URL \
     --build-arg DOWNLOADER_IMAGE=oscript-downloader \
     --build-arg DOWNLOADER_TAG=latest \

--- a/edt/Dockerfile
+++ b/edt/Dockerfile
@@ -38,7 +38,7 @@ ENV LC_ALL ru_RU.UTF-8
 
 RUN /download.sh "$ONEC_USERNAME" "$ONEC_PASSWORD" "$EDT_VERSION" "edt"
 
-FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG}
+FROM ${BASE_IMAGE}:${BASE_TAG}
 
 LABEL maintainer="Nikita Gryzlov <NikGryzlov@1bit.com>, FirstBit"
 
@@ -70,6 +70,8 @@ WORKDIR /tmp/${downloads}
 RUN chmod +x ./1ce-installer-cli \
   && ./1ce-installer-cli install all --ignore-hardware-checks --ignore-signature-warnings\
   && rm -rf /tmp/* \
-  && mv $(dirname $(find /opt/1C/1CE -name ring)) /opt/1C/1CE/components/1c-enterprise-ring
+  && mv $(dirname $(find /opt/1C/1CE -name ring)) /opt/1C/1CE/components/1c-enterprise-ring \
+  #1cedtcli отсутствует в EDT версии <2023.1.0
+  && if [ -n "$(find /opt/1C/1CE -name 1cedtcli)" ]; then mv $(dirname $(find /opt/1C/1CE -name 1cedtcli)) /opt/1C/1CE/components/1cedtcli; fi
 
-ENV PATH="/opt/1C/1CE/components/1c-enterprise-ring:$PATH"
+ENV PATH="/opt/1C/1CE/components/1c-enterprise-ring:/opt/1C/1CE/components/1cedtcli:$PATH"


### PR DESCRIPTION
1) при сборке образа добавил установку 1cedtcli в PATH (если этот файл существует)
1) скорректировал скрипты сборки EDT: 
- если версия EDT 2024 и выше, в качестве базового образа используется azul/zulu-openjdk 17
- по умолчанию базовый образ берется не из локального registry, а из интернета


> ВНИМАНИЕ! Не проверял сборку агента EDT под k8s и под Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Docker build scripts to dynamically select base images and tags based on the EDT version.
	- Improved installation process for the `1cedtcli` component within the Dockerfile.

- **Bug Fixes**
	- Streamlined the Dockerfile to simplify image sourcing and improve error handling.

- **Documentation**
	- Updated comments and logic in scripts for better clarity on version handling and installation processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->