### PR TITLE
Бампнул версию джавы для агента оскрипта и добавил локаль в образ edt

### DIFF
--- a/Layers.md
+++ b/Layers.md
@@ -55,7 +55,7 @@
 
 ## OneScript как Jenkins агент
 
-* oscript поверх library/adoptopenjdk:14-hotspot
+* oscript поверх library/eclipse-temurin:17
 * jenkins-agent
 
 ## Сервер хранилища + Apache

--- a/build-oscript-k8s-agent.sh
+++ b/build-oscript-k8s-agent.sh
@@ -23,8 +23,8 @@ docker build \
 	--pull \
     $no_cache_arg \
 	--build-arg DOCKER_REGISTRY_URL=library \
-    --build-arg BASE_IMAGE=adoptopenjdk \
-    --build-arg BASE_TAG=14-hotspot \
+    --build-arg BASE_IMAGE=eclipse-temurin \
+    --build-arg BASE_TAG=17 \
     -t $DOCKER_REGISTRY_URL/oscript-jdk:latest \
 	-f oscript/Dockerfile \
     $last_arg

--- a/build-oscript-swarm-agent.bat
+++ b/build-oscript-swarm-agent.bat
@@ -12,10 +12,10 @@ if %NO_CACHE%=="true" (SET last_arg="--no-cache .") else (SET last_arg=".")
 
 docker build ^
 	--pull ^
-	--build-arg DOCKER_REGISTRY_URL=%DOCKER_REGISTRY_URL% ^
-    --build-arg BASE_IMAGE=onec-client-vnc ^
-    --build-arg BASE_TAG=%ONEC_VERSION% ^
-    -t %DOCKER_REGISTRY_URL%/onec-client-vnc-oscript:%ONEC_VERSION% ^
+	--build-arg DOCKER_REGISTRY_URL=library ^
+    --build-arg BASE_IMAGE=eclipse-temurin ^
+    --build-arg BASE_TAG=17 ^
+    -t %DOCKER_REGISTRY_URL%/oscript-jdk:latest ^
     -f oscript/Dockerfile ^
     %last_arg%
 

--- a/build-oscript-swarm-agent.sh
+++ b/build-oscript-swarm-agent.sh
@@ -23,8 +23,8 @@ docker build \
 	--pull \
     $no_cache_arg \
 	--build-arg DOCKER_REGISTRY_URL=library \
-    --build-arg BASE_IMAGE=adoptopenjdk \
-    --build-arg BASE_TAG=14-hotspot \
+    --build-arg BASE_IMAGE=eclipse-temurin \
+    --build-arg BASE_TAG=17 \
     -t $DOCKER_REGISTRY_URL/oscript-jdk:latest \
 	-f oscript/Dockerfile \
     $last_arg

--- a/edt/Dockerfile
+++ b/edt/Dockerfile
@@ -60,7 +60,10 @@ RUN apt-get update \
 ARG EDT_VERSION=2021.3
 ARG downloads=downloads/DevelopmentTools10/${EDT_VERSION}
 
+# Установка переменных окружения для корректной работы локали
 ENV LANG ru_RU.UTF-8
+ENV LANGUAGE ru_RU:ru
+ENV LC_ALL ru_RU.UTF-8
 
 # Install EDT
 COPY --from=downloader /tmp/${downloads} /tmp/${downloads}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the base image for the `oscript` layer in the Jenkins agent documentation.

- **New Features**
	- Enhanced Docker build scripts to use the `eclipse-temurin:17` base image for improved performance and compatibility.

- **Improvements**
	- Streamlined dependency installation in the Dockerfile, including locale settings for better environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->