### PR TITLE
Независимый от версии EDT поиск jar-файлов для Coverage41C

### DIFF
--- a/coverage41C/Dockerfile
+++ b/coverage41C/Dockerfile
@@ -3,17 +3,17 @@ ARG BASE_IMAGE=edt
 ARG BASE_TAG
 ARG EDT_VERSION=2021.3
 ARG COVERAGE41C_VERSION=2.7.2
-ARG EDT_PLUGINS=/opt/1C/1CE/components/1c-edt-${EDT_VERSION}*-x86_64/plugins
 
 FROM ${DOCKER_REGISTRY_URL}/edt:${EDT_VERSION} as base
+
+RUN ln -s $(find /opt/1C -name "com._1c.g5.v8.dt.debug.*.jar" -printf '%h\n'| sort -u) /opt/1C/edt_plugins
 
 FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG}
 LABEL maintainer="Dima Ovcharenko <d.ovcharenko90@gmail.com>, Korus Consulting LLC"
 
 ARG COVERAGE41C_VERSION
-ARG EDT_PLUGINS
 
-COPY --from=base ${EDT_PLUGINS}/com._1c.g5.v8.dt.debug.core_*.jar ${EDT_PLUGINS}/com._1c.g5.v8.dt.debug.model_*.jar /opt/1C/1CE/
+COPY --from=base /opt/1C/edt_plugins/com._1c.g5.v8.dt.debug.core_*.jar /opt/1C/edt_plugins/com._1c.g5.v8.dt.debug.model_*.jar /opt/1C/1CE/
 
 ADD https://github.com/1c-syntax/Coverage41C/releases/download/v${COVERAGE41C_VERSION}/Coverage41C-${COVERAGE41C_VERSION}.tar \
     /opt/


### PR DESCRIPTION
Сделал так, что вместо использования ARG в базовом образе (EDT) выполняется поиск каталога с jar-файлами, на этот каталог формируется симлинк.

На втором стейдже файлы копируются из каталога, на который ведет симлинк.

closes #59 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Dockerfile for improved management of JAR files.
	- Removed the `EDT_PLUGINS` argument and implemented a symbolic link for better directory referencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->