### PR TITLE
Исправление сборки edt на windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 .env
 .onec.env
+env.bat
 build_info.txt
 .DS_Store
 dive.log

--- a/build-edt.bat
+++ b/build-edt.bat
@@ -1,6 +1,10 @@
 @echo off
 
-docker login -u %DOCKER_LOGIN% -p %DOCKER_PASSWORD% %DOCKER_REGISTRY_URL%
+if "%DOCKER_LOGIN%%DOCKER_PASSWORD%" neq "" (
+  docker login -u %DOCKER_LOGIN% -p %DOCKER_PASSWORD% %DOCKER_REGISTRY_URL%
+) else (
+  echo Skipping Docker login due to missing credentials
+)
 
 if %ERRORLEVEL% neq 0 goto end
 
@@ -8,7 +12,7 @@ if "%DOCKER_SYSTEM_PRUNE%"=="true" docker system prune -af
 
 if %ERRORLEVEL% neq 0 goto end
 
-for /f "delims=." %%a in ("%EDT_VERSION%") do set EDT_MAJOR_VERSION=%aa
+for /f "delims=." %%a in ("%EDT_VERSION%") do set EDT_MAJOR_VERSION=%%a
 if %EDT_MAJOR_VERSION% GEQ "2024" (
   set BASE_IMAGE="azul/zulu-openjdk"
   set BASE_TAG="17"
@@ -19,33 +23,39 @@ if %EDT_MAJOR_VERSION% GEQ "2024" (
 
 if %ERRORLEVEL% neq 0 goto end
 
-if %NO_CACHE%=="true" (SET last_arg="--no-cache .") else (SET last_arg=".")
+set no_cache_arg=
+if "%NO_CACHE%"=="true" (SET no_cache_arg="--no-cache")
 
+set last_arg=.
 set edt_version=%EDT_VERSION%
 set edt_escaped=%edt_version: =_%
 
 docker build ^
-        --pull ^
-        --build-arg DOCKER_REGISTRY_URL=library ^
+    --pull ^
+    %no_cache_arg% ^
+    --build-arg DOCKER_REGISTRY_URL=library ^
     --build-arg BASE_IMAGE=ubuntu ^
     --build-arg BASE_TAG=20.04 ^
     --build-arg ONESCRIPT_PACKAGES="yard" ^
     -t %DOCKER_REGISTRY_URL%/oscript-downloader:latest ^
-        -f oscript/Dockerfile ^
+    -f oscript/Dockerfile ^
     %last_arg%
 
 docker build ^
-        --build-arg ONEC_USERNAME=%ONEC_USERNAME% ^
-        --build-arg ONEC_PASSWORD=%ONEC_PASSWORD% ^
+    %no_cache_arg% ^
+    --build-arg ONEC_USERNAME=%ONEC_USERNAME% ^
+    --build-arg ONEC_PASSWORD=%ONEC_PASSWORD% ^
     --build-arg EDT_VERSION=%EDT_VERSION% ^
     --build-arg BASE_IMAGE=%BASE_IMAGE% ^
     --build-arg BASE_TAG=%BASE_TAG% ^
-    --build-arg DOCKER_REGISTRY_URL=%DOCKER_REGISTRY_URL% ^
+    --build-arg DOWNLOADER_REGISTRY_URL=%DOCKER_REGISTRY_URL% ^
     --build-arg DOWNLOADER_IMAGE=oscript-downloader ^
     --build-arg DOWNLOADER_TAG=latest ^
-        -t %DOCKER_REGISTRY_URL%/onec-client:%edt_escaped% ^
-        -f edt/Dockerfile ^
-        %last_arg%
+    -t %DOCKER_REGISTRY_URL%/edt:%edt_escaped% ^
+    -f edt/Dockerfile ^
+    %last_arg%
 
 if %ERRORLEVEL% neq 0 goto end
 
+:end
+echo End of program.


### PR DESCRIPTION
Скрипт сборки образа EDT на Windows исправлен и приведен в соответствие со скриптом под Linux, а именно:
- добавлен в игнор файл с переменными окружения `env.bat`, создаваемый согласно документации;
- авторизация в registry осуществляется только при наличии логина и пароля;
- исправлена ошибка вычисления мажорной версии EDT;
- исправлена ошибка использования опции `--no-cache` при сборке образов;
- исправлена ошибка передачи аргумента `DOWNLOADER_REGISTRY_URL` в докер-файл для образа EDT;
- задано корректное имя создаваемому образу;
- добавлена утерянная метка `end` скрипта.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to exclude the `env.bat` file from version control.
	- Enhanced the `build-edt.bat` script for improved Docker login handling and command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->