### PR TITLE
Добавить /opt/1cv8/current в PATH для onec-server

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.sh eol=lf
 configs/client-vnc/rootfs/etc/** eol=lf
+configs/pusk/rootfs/etc/** eol=lf

--- a/README.md
+++ b/README.md
@@ -8,79 +8,51 @@
 
 - [Описание](#описание)
 - [Использование](#использование)
-  - [Как сбилдить образы](#как-сбилдить-образы)
   - [Как запустить в docker-compose](#как-запустить-в-docker-compose)
   - [Как использовать готовые дистрибутивы](#как-использовать-готовые-дистрибутивы)
   - [Как использовать nethasp.ini в Jenkins + Docker Swarm plugin](#как-использовать-nethaspini-в-jenkins--docker-swarm-plugin)
 - [Оглавление](#оглавление)
+  - [EDT](#edt)
   - [Сервер](#сервер)
-  - [Сервер с дополнительными языками](#сервер-с-дополнительными-языками)
   - [Клиент](#клиент)
   - [Клиент с поддержкой VNC](#клиент-с-поддержкой-vnc)
-  - [Клиент с дополнительными языками](#клиент-с-дополнительными-языками)
-  - [Тонкий клиент](#тонкий-клиент)
-  - [Тонкий клиент с дополнительными языками](#тонкий-клиент-с-дополнительными-языками)
   - [Хранилище конфигурации](#хранилище-конфигурации)
-  - [rac-gui](#rac-gui)
-  - [gitsync](#gitsync)
-  - [oscript](#oscript)
-  - [vanessa-runner](#vanessa-runner)
-  - [EDT](#edt)
+  - [ПУСК](#пуск)
+
 
 # Использование
-
-В терминале введите:
-
-Команда Linux:
-```bash
-# для Linux
-$ cp .onec.env.example .onec.env
+Нужен регистри, например
+```shell
+docker run -d -p 5000:5000 --name registry --restart always -v local-registry-data:/var/lib/registry registry:2
 ```
-```batch
-:: для Windows
-copy .onec.env.bat.example env.bat
+Проверяем доступность регистри
+```shell
+curl -s -i -X GET http://registry.localhost:5000/v2/_catalog
 ```
 
-Скорректируйте файл `.onec.env` в соответствии со своим окружением:
-
-* ONEC_USERNAME - учётная запись на http://releases.1c.ru
-* ONEC_PASSWORD - пароль для учётной записи на http://releases.1c.ru
-* ONEC_VERSION - версия платформы 1С:Преприятия 8.3, которая будет в образе
-* EDT_VERSION - версия EDT. Обязательно заполнять только при сборке образов с EDT или при использовании замеров покрытия (см. `COVERAGE41C_VERSION`)
-* DOCKER_REGISTRY_URL - Адрес Docker-registry в котором будут храниться образы
-* COVERAGE41C_VERSION - версия Coverage41C
-Используется при сборке агента скриптами `build-base-*-jenkins-coverage-agent.*`.
-
-Затем экспортируйте все необходимые переменные:
-
-```bash
-# для Linux
-$ source .onec.env
+Создайте файл `.env` содержащий перменные среды
+ * `ONEC_USERNAME` и `ONEC_PASSWORD` - логин и пароль от информационно технологического сопровождения http://releases.1c.ru
+ * `ONEC_VERSION` - какую версию 1С использовать
+ * `EDT_VERSION` - какую версию ЕДТ использовать
+ * `DOCKER_` - доступный для пуша регистри для контейнеров
+ * `DOCKER_SYSTEM_PRUNE` - очистить перед сборкой незапущенные локальные контейнеры, неиспользуемые запущенными контейнерами тома, неиспользуемые запущенными контейнерами образы, используйте с осторожностью
 ```
-```batch
-:: для Windows
-env.bat
+ONEC_USERNAME=0000000
+ONEC_PASSWORD=password
+ONEC_VERSION=8.3.25.1546
+EDT_VERSION=2024.2.3
+
+DOCKER_REGISTRY_URL=localhost:5000
+DOCKER_LOGIN=login
+DOCKER_PASSWORD=pass
+DOCKER_SYSTEM_PRUNE=false
 ```
 
-## Как сбилдить образы
-
-:point_up: Запустите последовательно скрипты для сборки образов.
-
-1. Если вам нужны образы для использования в docker-swarm:
-
-    * build-base-swarm-jenkins-agent.sh (или build-base-swarm-jenkins-coverage-agent.sh с замерами покрытия)
-    * build-edt-swarm-agent.sh
-    * build-oscript-swarm-agent.sh
-
-2. Если же вы планируете использовать k8s:
-
-    * build-base-k8s-jenkins-agent.sh (или build-base-k8s-jenkins-coverage-agent.sh с замерами покрытия)
-    * build-edt-k8s-agent.sh
-    * build-oscript-k8s-agent.sh
+чего на bat и sh - не проврял, проверял исправлял скрипты ps1, выполнение скриптов предполагается в корневой директории (там где они лежат), в другой - не будет работать
 
 ## Как использовать готовые дистрибутивы
-
 Вы можете использовать готовые дистрибутивы платформы, для этого достаточно разместить их в папке `distr`. Скрипты будут автоматически использовать их для сборки образа.
+(не проверял, в каком виде их класть не понятно)
 
 ## Как использовать nethasp.ini в Jenkins + Docker Swarm plugin
 
@@ -88,141 +60,70 @@ env.bat
 - создать из него docker config командой `docker config create nethasp.ini ./nethasp.ini`
 - в Jenkins, в настройках Docker Agent templates у соответствующих агентов в параметре Configs указать `nethasp.ini:/opt/1cv8/current/conf/nethasp.ini`
 
-## Сервер
-[(Наверх)](#Оглавление)
+## EDT
+`./build-edt.ps1`
 
-```bash
-docker build --build-arg ONEC_USERNAME=${ONEC_USERNAME} \
-  --build-arg ONEC_PASSWORD=${ONEC_PASSWORD} \
-  --build-arg ONEC_VERSION=${ONEC_VERSION} \
-  -t ${DOCKER_REGISTRY_URL}/onec-server:${ONEC_VERSION} \
-  -f server/Dockerfile .
+Пример использования, временная или нет рабочей области, файлы src проекта EDT находятся здесь `D:\Projects\sample-onec-ws\sample-onec\edt-project\src`
+```shell
+docker run --rm -v "D:\Projects:/home/projects" -v "C:\Temp:/tmp/work" localhost:5000/edt:2024.2.3 1cedtcli -data "/tmp/tmp-edt-ws" -command export --project "/home/projects/sample-onec-ws/sample-onec/edt-project" --configuration-files "/tmp/work/1-0-0-1-3df46495/"
 ```
+в результате в `C:\Temp\1-0-0-1-3df46495` имеем конфигурационные файлы в формате 1С
 
-## Сервер с дополнительными языками
-[(Наверх)](#Оглавление)
+Пример использования, ранее созданная рабочая область находится здесь `D:/Projects/slk-ws`, в рабочей области есть проект с именем `acc3-edt`
+```shell
+docker run --rm -v "D:\Projects:/home/projects" -v "C:\Temp:/tmp/work" localhost:5000/edt:2024.2.3  1cedtcli -data "/home/projects/slk-ws" -command export --project-name "acc3-edt" --configuration-files "/tmp/work/3-0-177-16-d9104849/"
+```
+в результате изредка в `C:\Temp\3-0-177-16-d9104849` конфигурационные файлы в формате 1С
 
-```bash
-docker build --build-arg ONEC_USERNAME=${ONEC_USERNAME} \
-  --build-arg ONEC_PASSWORD=${ONEC_PASSWORD} \
-  --build-arg ONEC_VERSION=${ONEC_VERSION} \
-  --build-arg nls_enabled=true \
-  -t ${DOCKER_REGISTRY_URL}/onec-server-nls:${ONEC_VERSION} \
-  -f server/Dockerfile .
+## Сервер
+`./build-server.ps1`
+
+пример использования:
+```shell
+docker run --rm localhost:5000/onec-server:8.3.25.1546 /opt/1cv8/current/ibcmd --version
 ```
 
 ## Клиент
-[(Наверх)](#Оглавление)
+`./build-client.ps1`
 
-```bash
-docker build --build-arg ONEC_USERNAME=${ONEC_USERNAME} \
-  --build-arg ONEC_PASSWORD=${ONEC_PASSWORD} \
-  --build-arg ONEC_VERSION=${ONEC_VERSION} \
-  -t ${DOCKER_REGISTRY_URL}/onec-client:${ONEC_VERSION} \
-  -f client/Dockerfile .
+пример использования обновление конфигурации базы данных:
+```shell
+docker run --rm -v "E:\Issues\sample-onec:/home/dbpath" localhost:5000/onec-client:8.3.25.1546 /opt/1cv8/current/1cv8 DESIGNER /F"/home/dbpath" /UpdateDBCfg /DisableStartupDialogs /DisableStartupMessages /Out /home/dbpath/.log -NoTruncate
 ```
+в файле `E:\Issues\sample-onec\.log` - дописываются ошибки
 
 ## Клиент с поддержкой VNC
-[(Наверх)](#Оглавление)
+`./build-client-vnc.ps1`
 
-```bash
-docker build --build-arg DOCKER_REGISTRY_URL=${DOCKER_REGISTRY_URL} \
-  --build-arg ONEC_VERSION=${ONEC_VERSION} \
-  -t ${DOCKER_REGISTRY_URL}/onec-client-vnc:${ONEC_VERSION} \
-  -f client-vnc/Dockerfile .
-```
-
-## Клиент с дополнительными языками
-[(Наверх)](#Оглавление)
-
-```bash
-docker build --build-arg ONEC_USERNAME=${ONEC_USERNAME} \
-  --build-arg ONEC_PASSWORD=${ONEC_PASSWORD} \
-  --build-arg ONEC_VERSION=${ONEC_VERSION} \
-  --build-arg nls_enabled=true \
-  -t ${DOCKER_REGISTRY_URL}/onec-client-nls:${ONEC_VERSION} \
-  -f client/Dockerfile .
-```
-
-## Тонкий клиент
-[(Наверх)](#Оглавление)
-
-```bash
-docker build --build-arg ONEC_USERNAME=${ONEC_USERNAME} \
-  --build-arg ONEC_PASSWORD=${ONEC_PASSWORD} \
-  --build-arg ONEC_VERSION=${ONEC_VERSION} \
-  -t ${DOCKER_REGISTRY_URL}/onec-thin-client:${ONEC_VERSION} \
-  -f thin-client/Dockerfile .
-```
-
-## Тонкий клиент с дополнительными языками
-[(Наверх)](#Оглавление)
-
-```bash
-docker build --build-arg ONEC_USERNAME=${ONEC_USERNAME} \
-  --build-arg ONEC_PASSWORD=${ONEC_PASSWORD} \
-  --build-arg ONEC_VERSION=${ONEC_VERSION} \
-  --build-arg nls_enabled=true \
-  -t ${DOCKER_REGISTRY_URL}/onec-thin-client-nls:${ONEC_VERSION} \
-  -f thin-client/Dockerfile .
+Для проверки запускаем, на порту 5900 например с помошью RealVNC видим запущенную среду, можно добавить базу из каталога /home/dbpath
+```shell
+docker run --rm -p 5900:5900 -v "E:\Issues\sample-onec:/home/dbpath" localhost:5000/onec-client-vnc:8.3.25.1546
 ```
 
 ## Хранилище конфигурации
-[(Наверх)](#Оглавление)
+### Хранилище на tcp
+`./build-crs.ps1`
 
-```bash
-docker build --build-arg ONEC_USERNAME=${ONEC_USERNAME} \
-  --build-arg ONEC_PASSWORD=${ONEC_PASSWORD} \
-  --build-arg ONEC_VERSION=${ONEC_VERSION} \
-  -t ${DOCKER_REGISTRY_URL}/onec-crs:${ONEC_VERSION} \
-  -f crs/Dockerfile .
+Проверка: запустить
+```shell
+docker run --rm -v "C:\Temp\crs:/home/usr1cv8/.1cv8/crs" -p 1542:1542 localhost:5000/crs:8.3.25.1546
 ```
+попробовать создать хранилище tcp://localhost:1542/sample-svn
 
-## rac-gui
-[(Наверх)](#Оглавление)
+### Хранилище на http
+`./build-crs-apache.ps1`
 
-```bash
-docker build --build-arg DOCKER_REGISTRY_URL=${DOCKER_REGISTRY_URL} \
-  --build-arg ONEC_VERSION=${ONEC_VERSION} \
-  -t ${DOCKER_REGISTRY_URL}/onec-rac-gui:${ONEC_VERSION}-1.0.1 \
-  -f rac-gui/Dockerfile .
+Проверка
+```shell
+docker run --rm -v "C:\Temp\crs:/home/usr1cv8/.1cv8/crs" -p 1548:80 localhost:5000/crs-apache:8.3.25.1546
 ```
+ранее созданное хранилище должно быть доступно тут http://localhost:1548/crs/repo.1ccr/sample-svn
 
-## gitsync
-[(Наверх)](#Оглавление)
+## ПУСК
+`./build-pusk.ps1`
 
-```bash
-docker build --build-arg DOCKER_REGISTRY_URL=${DOCKER_REGISTRY_URL} \
-  --build-arg ONEC_VERSION=${ONEC_VERSION} \
-  -t ${DOCKER_REGISTRY_URL}/gitsync:3.0.0 \
-  -f gitsync/Dockerfile .
+Проверка: `pusk/application.properties.example` положить в `C:\Temp\pusk\data\application.properties`, в `C:\Temp\pusk\log` - журналы
+```shell
+docker run --rm -v "C:\Temp\pusk\log:/opt/pusk/log" -v "C:\Temp\pusk\data:/opt/pusk/data" -p 8085:8080 localhost:5000/pusk:1.2.1
 ```
-
-## oscript
-[(Наверх)](#Оглавление)
-
-```bash
-docker build --build-arg DOCKER_REGISTRY_URL=${DOCKER_REGISTRY_URL} \
-  --build-arg ONEC_VERSION=${ONEC_VERSION} \
-  -t ${DOCKER_REGISTRY_URL}/oscript:1.0.21 \
-  -f oscript/Dockerfile .
-```
-
-## vanessa-runner
-[(Наверх)](#Оглавление)
-
-```bash
-docker build --build-arg DOCKER_REGISTRY_URL=${DOCKER_REGISTRY_URL} \
-  -t ${DOCKER_REGISTRY_URL}/runner:1.7.0 \
-  -f vanessa-runner/Dockerfile .
-```
-
-## EDT
-[(Наверх)](#Оглавление)
-```bash
-docker build --build-arg ONEC_USERNAME=${ONEC_USERNAME} \
-    --build-arg ONEC_PASSWORD=${ONEC_PASSWORD} \
-    --build-arg EDT_VERSION=${EDT_VERSION} \
-    -t ${DOCKER_REGISTRY_URL}/edt:${EDT_VERSION} \
-    -f edt/Dockerfile .
-```
+браузер localhost:8085 видим что-то хорошее, управление сервисами - не работает.

--- a/build-client-vnc.ps1
+++ b/build-client-vnc.ps1
@@ -1,0 +1,54 @@
+$envFilePath = ".env"
+
+# Чтение .env файла и загрузка переменных окружения
+if (Test-Path $envFilePath) {
+    Get-Content $envFilePath | ForEach-Object {
+        if ($_ -match '^(?<key>[^=]+)=(?<value>.*)$') {
+            $key = $matches['key'].Trim()
+            $value = $matches['value'].Trim()
+            [System.Environment]::SetEnvironmentVariable($key, $value)
+        }
+    }
+}
+
+if (-not [string]::IsNullOrEmpty($env:DOCKER_LOGIN) -and -not [string]::IsNullOrEmpty($env:DOCKER_PASSWORD) -and -not [string]::IsNullOrEmpty($env:DOCKER_REGISTRY_URL)) {
+    docker login -u $env:DOCKER_LOGIN -p $env:DOCKER_PASSWORD $env:DOCKER_REGISTRY_URL
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Docker login failed"
+        exit 1
+    }
+} else {
+    Write-Host "Skipping Docker login due to missing credentials"
+}
+
+if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
+    docker system prune -af
+}
+
+$last_arg = '.'
+if ($env:NO_CACHE -eq 'true') {
+    $last_arg = '--no-cache .'
+}
+
+docker build `
+    --pull `
+    --build-arg DOCKER_REGISTRY_URL=library `
+    --build-arg BASE_IMAGE=ubuntu `
+    --build-arg BASE_TAG=20.04 `
+    --build-arg ONESCRIPT_PACKAGES="yard" `
+    -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
+    -f oscript/Dockerfile `
+    $last_arg
+
+docker build `
+    --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
+    --build-arg ONEC_PASSWORD=$env:ONEC_PASSWORD `
+    --build-arg ONEC_VERSION=$env:ONEC_VERSION `
+    --build-arg DOCKER_REGISTRY_URL=$env:DOCKER_REGISTRY_URL `
+    --build-arg BASE_IMAGE=oscript-downloader `
+    --build-arg BASE_TAG=latest `
+    -t "$($env:DOCKER_REGISTRY_URL)/onec-client-vnc:$($env:ONEC_VERSION)" `
+    -f client-vnc/Dockerfile `
+    $last_arg
+
+docker push "$($env:DOCKER_REGISTRY_URL)/onec-client-vnc:$($env:ONEC_VERSION)"

--- a/build-client-vnc.ps1
+++ b/build-client-vnc.ps1
@@ -47,6 +47,17 @@ docker build `
     --build-arg DOCKER_REGISTRY_URL=$env:DOCKER_REGISTRY_URL `
     --build-arg BASE_IMAGE=oscript-downloader `
     --build-arg BASE_TAG=latest `
+    -t "$($env:DOCKER_REGISTRY_URL)/onec-client:$($env:ONEC_VERSION)" `
+    -f client/Dockerfile `
+    $last_arg
+
+docker build `
+    --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
+    --build-arg ONEC_PASSWORD=$env:ONEC_PASSWORD `
+    --build-arg ONEC_VERSION=$env:ONEC_VERSION `
+    --build-arg DOCKER_REGISTRY_URL=$env:DOCKER_REGISTRY_URL `
+    --build-arg BASE_IMAGE=onec-client `
+    --build-arg BASE_TAG=$env:ONEC_VERSION `
     -t "$($env:DOCKER_REGISTRY_URL)/onec-client-vnc:$($env:ONEC_VERSION)" `
     -f client-vnc/Dockerfile `
     $last_arg

--- a/build-client-vnc.ps1
+++ b/build-client-vnc.ps1
@@ -25,11 +25,6 @@ if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
     docker system prune -af
 }
 
-$last_arg = '.'
-if ($env:NO_CACHE -eq 'true') {
-    $last_arg = '--no-cache .'
-}
-
 docker build `
     --pull `
     --build-arg DOCKER_REGISTRY_URL=library `
@@ -37,8 +32,7 @@ docker build `
     --build-arg BASE_TAG=20.04 `
     --build-arg ONESCRIPT_PACKAGES="yard" `
     -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
-    -f oscript/Dockerfile `
-    $last_arg
+    -f oscript/Dockerfile .
 
 docker build `
     --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
@@ -48,8 +42,7 @@ docker build `
     --build-arg BASE_IMAGE=oscript-downloader `
     --build-arg BASE_TAG=latest `
     -t "$($env:DOCKER_REGISTRY_URL)/onec-client:$($env:ONEC_VERSION)" `
-    -f client/Dockerfile `
-    $last_arg
+    -f client/Dockerfile .
 
 docker build `
     --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
@@ -59,7 +52,6 @@ docker build `
     --build-arg BASE_IMAGE=onec-client `
     --build-arg BASE_TAG=$env:ONEC_VERSION `
     -t "$($env:DOCKER_REGISTRY_URL)/onec-client-vnc:$($env:ONEC_VERSION)" `
-    -f client-vnc/Dockerfile `
-    $last_arg
+    -f client-vnc/Dockerfile .
 
 docker push "$($env:DOCKER_REGISTRY_URL)/onec-client-vnc:$($env:ONEC_VERSION)"

--- a/build-client.ps1
+++ b/build-client.ps1
@@ -1,0 +1,54 @@
+$envFilePath = ".env"
+
+# Чтение .env файла и загрузка переменных окружения
+if (Test-Path $envFilePath) {
+    Get-Content $envFilePath | ForEach-Object {
+        if ($_ -match '^(?<key>[^=]+)=(?<value>.*)$') {
+            $key = $matches['key'].Trim()
+            $value = $matches['value'].Trim()
+            [System.Environment]::SetEnvironmentVariable($key, $value)
+        }
+    }
+}
+
+if (-not [string]::IsNullOrEmpty($env:DOCKER_LOGIN) -and -not [string]::IsNullOrEmpty($env:DOCKER_PASSWORD) -and -not [string]::IsNullOrEmpty($env:DOCKER_REGISTRY_URL)) {
+    docker login -u $env:DOCKER_LOGIN -p $env:DOCKER_PASSWORD $env:DOCKER_REGISTRY_URL
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Docker login failed"
+        exit 1
+    }
+} else {
+    Write-Host "Skipping Docker login due to missing credentials"
+}
+
+if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
+    docker system prune -af
+}
+
+$last_arg = '.'
+if ($env:NO_CACHE -eq 'true') {
+    $last_arg = '--no-cache .'
+}
+
+docker build `
+    --pull `
+    --build-arg DOCKER_REGISTRY_URL=library `
+    --build-arg BASE_IMAGE=ubuntu `
+    --build-arg BASE_TAG=20.04 `
+    --build-arg ONESCRIPT_PACKAGES="yard" `
+    -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
+    -f oscript/Dockerfile `
+    $last_arg
+
+docker build `
+    --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
+    --build-arg ONEC_PASSWORD=$env:ONEC_PASSWORD `
+    --build-arg ONEC_VERSION=$env:ONEC_VERSION `
+    --build-arg DOCKER_REGISTRY_URL=$env:DOCKER_REGISTRY_URL `
+    --build-arg BASE_IMAGE=oscript-downloader `
+    --build-arg BASE_TAG=latest `
+    -t "$($env:DOCKER_REGISTRY_URL)/onec-client:$($env:ONEC_VERSION)" `
+    -f client/Dockerfile `
+    $last_arg
+
+docker push "$($env:DOCKER_REGISTRY_URL)/onec-client:$($env:ONEC_VERSION)"

--- a/build-client.ps1
+++ b/build-client.ps1
@@ -25,11 +25,6 @@ if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
     docker system prune -af
 }
 
-$last_arg = '.'
-if ($env:NO_CACHE -eq 'true') {
-    $last_arg = '--no-cache .'
-}
-
 docker build `
     --pull `
     --build-arg DOCKER_REGISTRY_URL=library `
@@ -37,8 +32,7 @@ docker build `
     --build-arg BASE_TAG=20.04 `
     --build-arg ONESCRIPT_PACKAGES="yard" `
     -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
-    -f oscript/Dockerfile `
-    $last_arg
+    -f oscript/Dockerfile .
 
 docker build `
     --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
@@ -48,7 +42,6 @@ docker build `
     --build-arg BASE_IMAGE=oscript-downloader `
     --build-arg BASE_TAG=latest `
     -t "$($env:DOCKER_REGISTRY_URL)/onec-client:$($env:ONEC_VERSION)" `
-    -f client/Dockerfile `
-    $last_arg
+    -f client/Dockerfile .
 
 docker push "$($env:DOCKER_REGISTRY_URL)/onec-client:$($env:ONEC_VERSION)"

--- a/build-crs-apache.ps1
+++ b/build-crs-apache.ps1
@@ -1,0 +1,76 @@
+$envFilePath = ".env"
+
+# Чтение .env файла и загрузка переменных окружения
+if (Test-Path $envFilePath) {
+    Get-Content $envFilePath | ForEach-Object {
+        if ($_ -match '^(?<key>[^=]+)=(?<value>.*)$') {
+            $key = $matches['key'].Trim()
+            $value = $matches['value'].Trim()
+            [System.Environment]::SetEnvironmentVariable($key, $value)
+        }
+    }
+}
+
+if (-not [string]::IsNullOrEmpty($env:DOCKER_LOGIN) -and -not [string]::IsNullOrEmpty($env:DOCKER_PASSWORD) -and -not [string]::IsNullOrEmpty($env:DOCKER_REGISTRY_URL)) {
+    docker login -u $env:DOCKER_LOGIN -p $env:DOCKER_PASSWORD $env:DOCKER_REGISTRY_URL
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Docker login failed"
+        exit 1
+    }
+} else {
+    Write-Host "Skipping Docker login due to missing credentials"
+}
+
+if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
+    docker system prune -af
+}
+
+$last_arg = '.'
+if ($env:NO_CACHE -eq 'true') {
+    $last_arg = '--no-cache .'
+}
+
+docker build `
+    --pull `
+    --build-arg DOCKER_REGISTRY_URL=library `
+    --build-arg BASE_IMAGE=ubuntu `
+    --build-arg BASE_TAG=20.04 `
+    --build-arg ONESCRIPT_PACKAGES="yard" `
+    -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
+    -f oscript/Dockerfile `
+    $last_arg
+
+docker build `
+    --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
+    --build-arg ONEC_PASSWORD=$env:ONEC_PASSWORD `
+    --build-arg ONEC_VERSION=$env:ONEC_VERSION `
+    --build-arg DOCKER_REGISTRY_URL=$env:DOCKER_REGISTRY_URL `
+    --build-arg BASE_IMAGE=oscript-downloader `
+    --build-arg BASE_TAG=latest `
+    -t "$($env:DOCKER_REGISTRY_URL)/onec-server:$($env:ONEC_VERSION)" `
+    -f server/Dockerfile `
+    $last_arg
+
+docker build `
+    --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
+    --build-arg ONEC_PASSWORD=$env:ONEC_PASSWORD `
+    --build-arg ONEC_VERSION=$env:ONEC_VERSION `
+    --build-arg DOCKER_REGISTRY_URL=$env:DOCKER_REGISTRY_URL `
+    --build-arg BASE_IMAGE=onec-server `
+    --build-arg BASE_TAG=$env:ONEC_VERSION `
+    -t "$($env:DOCKER_REGISTRY_URL)/crs:$($env:ONEC_VERSION)" `
+    -f crs/Dockerfile `
+    $last_arg
+
+    docker build `
+    --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
+    --build-arg ONEC_PASSWORD=$env:ONEC_PASSWORD `
+    --build-arg ONEC_VERSION=$env:ONEC_VERSION `
+    --build-arg DOCKER_REGISTRY_URL=$env:DOCKER_REGISTRY_URL `
+    --build-arg BASE_IMAGE=crs `
+    --build-arg BASE_TAG=$env:ONEC_VERSION `
+    -t "$($env:DOCKER_REGISTRY_URL)/crs-apache:$($env:ONEC_VERSION)" `
+    -f crs-apache/Dockerfile `
+    $last_arg
+
+docker push "$($env:DOCKER_REGISTRY_URL)/crs-apache:$($env:ONEC_VERSION)"

--- a/build-crs-apache.ps1
+++ b/build-crs-apache.ps1
@@ -25,11 +25,6 @@ if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
     docker system prune -af
 }
 
-$last_arg = '.'
-if ($env:NO_CACHE -eq 'true') {
-    $last_arg = '--no-cache .'
-}
-
 docker build `
     --pull `
     --build-arg DOCKER_REGISTRY_URL=library `
@@ -37,8 +32,7 @@ docker build `
     --build-arg BASE_TAG=20.04 `
     --build-arg ONESCRIPT_PACKAGES="yard" `
     -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
-    -f oscript/Dockerfile `
-    $last_arg
+    -f oscript/Dockerfile .
 
 docker build `
     --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
@@ -48,8 +42,7 @@ docker build `
     --build-arg BASE_IMAGE=oscript-downloader `
     --build-arg BASE_TAG=latest `
     -t "$($env:DOCKER_REGISTRY_URL)/onec-server:$($env:ONEC_VERSION)" `
-    -f server/Dockerfile `
-    $last_arg
+    -f server/Dockerfile .
 
 docker build `
     --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
@@ -59,8 +52,7 @@ docker build `
     --build-arg BASE_IMAGE=onec-server `
     --build-arg BASE_TAG=$env:ONEC_VERSION `
     -t "$($env:DOCKER_REGISTRY_URL)/crs:$($env:ONEC_VERSION)" `
-    -f crs/Dockerfile `
-    $last_arg
+    -f crs/Dockerfile .
 
     docker build `
     --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
@@ -70,7 +62,6 @@ docker build `
     --build-arg BASE_IMAGE=crs `
     --build-arg BASE_TAG=$env:ONEC_VERSION `
     -t "$($env:DOCKER_REGISTRY_URL)/crs-apache:$($env:ONEC_VERSION)" `
-    -f crs-apache/Dockerfile `
-    $last_arg
+    -f crs-apache/Dockerfile .
 
 docker push "$($env:DOCKER_REGISTRY_URL)/crs-apache:$($env:ONEC_VERSION)"

--- a/build-crs.ps1
+++ b/build-crs.ps1
@@ -25,11 +25,6 @@ if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
     docker system prune -af
 }
 
-$last_arg = '.'
-if ($env:NO_CACHE -eq 'true') {
-    $last_arg = '--no-cache .'
-}
-
 docker build `
     --pull `
     --build-arg DOCKER_REGISTRY_URL=library `
@@ -37,8 +32,7 @@ docker build `
     --build-arg BASE_TAG=20.04 `
     --build-arg ONESCRIPT_PACKAGES="yard" `
     -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
-    -f oscript/Dockerfile `
-    $last_arg
+    -f oscript/Dockerfile .
 
 docker build `
     --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
@@ -48,8 +42,7 @@ docker build `
     --build-arg BASE_IMAGE=oscript-downloader `
     --build-arg BASE_TAG=latest `
     -t "$($env:DOCKER_REGISTRY_URL)/onec-server:$($env:ONEC_VERSION)" `
-    -f server/Dockerfile `
-    $last_arg
+    -f server/Dockerfile .
 
 docker build `
     --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
@@ -59,7 +52,6 @@ docker build `
     --build-arg BASE_IMAGE=onec-server `
     --build-arg BASE_TAG=$env:ONEC_VERSION `
     -t "$($env:DOCKER_REGISTRY_URL)/crs:$($env:ONEC_VERSION)" `
-    -f crs/Dockerfile `
-    $last_arg
+    -f crs/Dockerfile .
 
 docker push "$($env:DOCKER_REGISTRY_URL)/crs:$($env:ONEC_VERSION)"

--- a/build-crs.ps1
+++ b/build-crs.ps1
@@ -1,0 +1,65 @@
+$envFilePath = ".env"
+
+# Чтение .env файла и загрузка переменных окружения
+if (Test-Path $envFilePath) {
+    Get-Content $envFilePath | ForEach-Object {
+        if ($_ -match '^(?<key>[^=]+)=(?<value>.*)$') {
+            $key = $matches['key'].Trim()
+            $value = $matches['value'].Trim()
+            [System.Environment]::SetEnvironmentVariable($key, $value)
+        }
+    }
+}
+
+if (-not [string]::IsNullOrEmpty($env:DOCKER_LOGIN) -and -not [string]::IsNullOrEmpty($env:DOCKER_PASSWORD) -and -not [string]::IsNullOrEmpty($env:DOCKER_REGISTRY_URL)) {
+    docker login -u $env:DOCKER_LOGIN -p $env:DOCKER_PASSWORD $env:DOCKER_REGISTRY_URL
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Docker login failed"
+        exit 1
+    }
+} else {
+    Write-Host "Skipping Docker login due to missing credentials"
+}
+
+if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
+    docker system prune -af
+}
+
+$last_arg = '.'
+if ($env:NO_CACHE -eq 'true') {
+    $last_arg = '--no-cache .'
+}
+
+docker build `
+    --pull `
+    --build-arg DOCKER_REGISTRY_URL=library `
+    --build-arg BASE_IMAGE=ubuntu `
+    --build-arg BASE_TAG=20.04 `
+    --build-arg ONESCRIPT_PACKAGES="yard" `
+    -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
+    -f oscript/Dockerfile `
+    $last_arg
+
+docker build `
+    --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
+    --build-arg ONEC_PASSWORD=$env:ONEC_PASSWORD `
+    --build-arg ONEC_VERSION=$env:ONEC_VERSION `
+    --build-arg DOCKER_REGISTRY_URL=$env:DOCKER_REGISTRY_URL `
+    --build-arg BASE_IMAGE=oscript-downloader `
+    --build-arg BASE_TAG=latest `
+    -t "$($env:DOCKER_REGISTRY_URL)/onec-server:$($env:ONEC_VERSION)" `
+    -f server/Dockerfile `
+    $last_arg
+
+docker build `
+    --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
+    --build-arg ONEC_PASSWORD=$env:ONEC_PASSWORD `
+    --build-arg ONEC_VERSION=$env:ONEC_VERSION `
+    --build-arg DOCKER_REGISTRY_URL=$env:DOCKER_REGISTRY_URL `
+    --build-arg BASE_IMAGE=onec-server `
+    --build-arg BASE_TAG=$env:ONEC_VERSION `
+    -t "$($env:DOCKER_REGISTRY_URL)/crs:$($env:ONEC_VERSION)" `
+    -f crs/Dockerfile `
+    $last_arg
+
+docker push "$($env:DOCKER_REGISTRY_URL)/crs:$($env:ONEC_VERSION)"

--- a/build-edt.ps1
+++ b/build-edt.ps1
@@ -1,0 +1,65 @@
+$envFilePath = ".env"
+
+# Чтение .env файла и загрузка переменных окружения
+if (Test-Path $envFilePath) {
+    Get-Content $envFilePath | ForEach-Object {
+        if ($_ -match '^(?<key>[^=]+)=(?<value>.*)$') {
+            $key = $matches['key'].Trim()
+            $value = $matches['value'].Trim()
+            [System.Environment]::SetEnvironmentVariable($key, $value)
+        }
+    }
+}
+
+if (-not [string]::IsNullOrEmpty($env:DOCKER_LOGIN) -and -not [string]::IsNullOrEmpty($env:DOCKER_PASSWORD) -and -not [string]::IsNullOrEmpty($env:DOCKER_REGISTRY_URL)) {
+    docker login -u $env:DOCKER_LOGIN -p $env:DOCKER_PASSWORD $env:DOCKER_REGISTRY_URL
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Docker login failed"
+        exit 1
+    }
+} else {
+    Write-Host "Skipping Docker login due to missing credentials"
+}
+
+if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
+    docker system prune -af
+}
+
+$EDT_MAJOR_VERSION = $env:EDT_VERSION.Split('.')[0]
+if ([int]$EDT_MAJOR_VERSION -ge 2024) {
+    $env:BASE_IMAGE = "azul/zulu-openjdk"
+    $env:BASE_TAG = "17"
+} else {
+    $env:BASE_IMAGE = "eclipse-temurin"
+    $env:BASE_TAG = "11"
+}
+
+$last_arg = '.'
+if ($env:NO_CACHE -eq 'true') {
+    $last_arg = '--no-cache .'
+}
+
+docker build `
+    --pull `
+    --build-arg DOCKER_REGISTRY_URL=library `
+    --build-arg BASE_IMAGE=ubuntu `
+    --build-arg BASE_TAG=20.04 `
+    --build-arg ONESCRIPT_PACKAGES="yard" `
+    -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
+    -f oscript/Dockerfile `
+    $last_arg
+
+docker build `
+    --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
+    --build-arg ONEC_PASSWORD=$env:ONEC_PASSWORD `
+    --build-arg EDT_VERSION=$env:EDT_VERSION `
+    --build-arg DOCKER_REGISTRY_URL=$env:DOCKER_REGISTRY_URL `
+    --build-arg BASE_IMAGE=$env:BASE_IMAGE `
+    --build-arg BASE_TAG=$env:BASE_TAG `
+    --build-arg DOWNLOADER_IMAGE=oscript-downloader `
+    --build-arg DOWNLOADER_TAG=latest `
+    -t "$($env:DOCKER_REGISTRY_URL)/edt:$($env:EDT_VERSION)" `
+    -f edt/Dockerfile `
+    $last_arg
+
+docker push "$($env:DOCKER_REGISTRY_URL)/edt:$($env:EDT_VERSION)"

--- a/build-edt.ps1
+++ b/build-edt.ps1
@@ -25,6 +25,15 @@ if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
     docker system prune -af
 }
 
+docker build `
+    --pull `
+    --build-arg DOCKER_REGISTRY_URL=library `
+    --build-arg BASE_IMAGE=ubuntu `
+    --build-arg BASE_TAG=20.04 `
+    --build-arg ONESCRIPT_PACKAGES="yard" `
+    -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
+    -f oscript/Dockerfile .
+
 $EDT_MAJOR_VERSION = $env:EDT_VERSION.Split('.')[0]
 if ([int]$EDT_MAJOR_VERSION -ge 2024) {
     $env:BASE_IMAGE = "azul/zulu-openjdk"
@@ -33,21 +42,6 @@ if ([int]$EDT_MAJOR_VERSION -ge 2024) {
     $env:BASE_IMAGE = "eclipse-temurin"
     $env:BASE_TAG = "11"
 }
-
-$last_arg = '.'
-if ($env:NO_CACHE -eq 'true') {
-    $last_arg = '--no-cache .'
-}
-
-docker build `
-    --pull `
-    --build-arg DOCKER_REGISTRY_URL=library `
-    --build-arg BASE_IMAGE=ubuntu `
-    --build-arg BASE_TAG=20.04 `
-    --build-arg ONESCRIPT_PACKAGES="yard" `
-    -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
-    -f oscript/Dockerfile `
-    $last_arg
 
 docker build `
     --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
@@ -59,7 +53,6 @@ docker build `
     --build-arg DOWNLOADER_IMAGE=oscript-downloader `
     --build-arg DOWNLOADER_TAG=latest `
     -t "$($env:DOCKER_REGISTRY_URL)/edt:$($env:EDT_VERSION)" `
-    -f edt/Dockerfile `
-    $last_arg
+    -f edt/Dockerfile .`
 
 docker push "$($env:DOCKER_REGISTRY_URL)/edt:$($env:EDT_VERSION)"

--- a/build-pusk.ps1
+++ b/build-pusk.ps1
@@ -1,0 +1,29 @@
+$envFilePath = ".env"
+
+# Чтение .env файла и загрузка переменных окружения
+if (Test-Path $envFilePath) {
+    Get-Content $envFilePath | ForEach-Object {
+        if ($_ -match '^(?<key>[^=]+)=(?<value>.*)$') {
+            $key = $matches['key'].Trim()
+            $value = $matches['value'].Trim()
+            [System.Environment]::SetEnvironmentVariable($key, $value)
+        }
+    }
+}
+
+if (-not [string]::IsNullOrEmpty($env:DOCKER_LOGIN) -and -not [string]::IsNullOrEmpty($env:DOCKER_PASSWORD) -and -not [string]::IsNullOrEmpty($env:DOCKER_REGISTRY_URL)) {
+    docker login -u $env:DOCKER_LOGIN -p $env:DOCKER_PASSWORD $env:DOCKER_REGISTRY_URL
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Docker login failed"
+        exit 1
+    }
+} else {
+    Write-Host "Skipping Docker login due to missing credentials"
+}
+
+docker build `
+    --tag "$($env:DOCKER_REGISTRY_URL)/pusk:1.2.1" `
+    --file pusk/Dockerfile `
+    .
+
+docker push "$($env:DOCKER_REGISTRY_URL)/pusk:1.2.1"

--- a/build-server.ps1
+++ b/build-server.ps1
@@ -1,0 +1,54 @@
+$envFilePath = ".env"
+
+# Чтение .env файла и загрузка переменных окружения
+if (Test-Path $envFilePath) {
+    Get-Content $envFilePath | ForEach-Object {
+        if ($_ -match '^(?<key>[^=]+)=(?<value>.*)$') {
+            $key = $matches['key'].Trim()
+            $value = $matches['value'].Trim()
+            [System.Environment]::SetEnvironmentVariable($key, $value)
+        }
+    }
+}
+
+if (-not [string]::IsNullOrEmpty($env:DOCKER_LOGIN) -and -not [string]::IsNullOrEmpty($env:DOCKER_PASSWORD) -and -not [string]::IsNullOrEmpty($env:DOCKER_REGISTRY_URL)) {
+    docker login -u $env:DOCKER_LOGIN -p $env:DOCKER_PASSWORD $env:DOCKER_REGISTRY_URL
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Docker login failed"
+        exit 1
+    }
+} else {
+    Write-Host "Skipping Docker login due to missing credentials"
+}
+
+if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
+    docker system prune -af
+}
+
+$last_arg = '.'
+if ($env:NO_CACHE -eq 'true') {
+    $last_arg = '--no-cache .'
+}
+
+docker build `
+    --pull `
+    --build-arg DOCKER_REGISTRY_URL=library `
+    --build-arg BASE_IMAGE=ubuntu `
+    --build-arg BASE_TAG=20.04 `
+    --build-arg ONESCRIPT_PACKAGES="yard" `
+    -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
+    -f oscript/Dockerfile `
+    $last_arg
+
+docker build `
+    --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
+    --build-arg ONEC_PASSWORD=$env:ONEC_PASSWORD `
+    --build-arg ONEC_VERSION=$env:ONEC_VERSION `
+    --build-arg DOCKER_REGISTRY_URL=$env:DOCKER_REGISTRY_URL `
+    --build-arg BASE_IMAGE=oscript-downloader `
+    --build-arg BASE_TAG=latest `
+    -t "$($env:DOCKER_REGISTRY_URL)/onec-server:$($env:ONEC_VERSION)" `
+    -f server/Dockerfile `
+    $last_arg
+
+docker push "$($env:DOCKER_REGISTRY_URL)/onec-server:$($env:ONEC_VERSION)"

--- a/build-server.ps1
+++ b/build-server.ps1
@@ -25,11 +25,6 @@ if ($env:DOCKER_SYSTEM_PRUNE -eq 'true') {
     docker system prune -af
 }
 
-$last_arg = '.'
-if ($env:NO_CACHE -eq 'true') {
-    $last_arg = '--no-cache .'
-}
-
 docker build `
     --pull `
     --build-arg DOCKER_REGISTRY_URL=library `
@@ -37,8 +32,7 @@ docker build `
     --build-arg BASE_TAG=20.04 `
     --build-arg ONESCRIPT_PACKAGES="yard" `
     -t "$($env:DOCKER_REGISTRY_URL)/oscript-downloader:latest" `
-    -f oscript/Dockerfile `
-    $last_arg
+    -f oscript/Dockerfile .
 
 docker build `
     --build-arg ONEC_USERNAME=$env:ONEC_USERNAME `
@@ -48,7 +42,6 @@ docker build `
     --build-arg BASE_IMAGE=oscript-downloader `
     --build-arg BASE_TAG=latest `
     -t "$($env:DOCKER_REGISTRY_URL)/onec-server:$($env:ONEC_VERSION)" `
-    -f server/Dockerfile `
-    $last_arg
+    -f server/Dockerfile .
 
 docker push "$($env:DOCKER_REGISTRY_URL)/onec-server:$($env:ONEC_VERSION)"

--- a/client-vnc/Dockerfile
+++ b/client-vnc/Dockerfile
@@ -1,94 +1,41 @@
 ARG DOCKER_REGISTRY_URL=localhost:5000
-ARG ONEC_VERSION=8.3.25.1546
-FROM ${DOCKER_REGISTRY_URL}/onec-client:${ONEC_VERSION} AS base
+ARG BASE_IMAGE=onec-client
+ARG BASE_TAG=8.3.25.1546
+FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG} AS onecclient
 
-FROM debian:bullseye-slim
-ARG ONEC_VERSION
+ADD https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-amd64-installer /tmp/s6-overlay-installer
 
-COPY --from=base /opt /opt
+ARG onec_uid="999"
+ARG onec_gid="999"
 
-ADD https://github.com/just-containers/s6-overlay/releases/download/v1.21.8.0/s6-overlay-amd64.tar.gz /tmp/
+USER root
 
 RUN apt-get update \
-  && apt-mark hold iptables \
-  && env DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-    dbus-x11 \
-    psmisc \
-    x11-utils \
-    x11-xserver-utils \
-    xdg-utils \
-    xvfb \
-  && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    xfce4 \
-    xfce4-goodies \
-  && sed -i 's%<property name="ThemeName" type="string" value="Xfce"/>%<property name="ThemeName" type="string" value="Raleigh"/>%' /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    dirmngr \
-    gnupg \
-  && echo "deb http://http.debian.net/debian/ bullseye main contrib non-free" > /etc/apt/sources.list \
-  && echo "deb http://http.debian.net/debian/ bullseye-backports main" >> /etc/apt/sources.list \
-  && echo "deb http://http.debian.net/debian/ bullseye-proposed-updates main contrib non-free" >> /etc/apt/sources.list \
-  && echo "deb http://security.debian.org/debian-security/ bullseye-security main contrib non-free" >> /etc/apt/sources.list \
-  && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
-  && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-    at-spi2-core \
-    ca-certificates \
-    git \
-    iproute2 \
-    libfontconfig1 \
-    libglib2.0-0 \
-    libgsf-1-114 \
-    libgtk2.0-0 \
-    libmagickwand-6.q16-6 \
-    libodbc1 \
-    libtcmalloc-minimal4 \
-    libwebkit2gtk-4.0-37 \
-    locales \
-    procps \
-    ttf-mscorefonts-installer \
-    x11vnc \
-  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 40976EAF437D05B5 \
-  && echo "deb http://security.ubuntu.com/ubuntu xenial-security main" > /etc/apt/sources.list.d/xenial-security.list \
-  && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      libpng12-0 \
-  && rm -rf  /etc/apt/sources.list.d/xenial-security.list \
-  && apt-get update \
-  # Install libwebkitgtk from stretch
-  && echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list.d/stretch.list \
-  && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    libwebkitgtk-3.0-0 \
-  && rm -rf  /etc/apt/sources.list.d/stretch.list \
-  && apt-get update \
-  && rm -rf  \
-    /var/lib/apt/lists/* \
-    /var/cache/debconf \
-  && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
-ENV LANG=ru_RU.UTF-8
-
-# remove DST Root CA X3 cert if it exists
-COPY ./scripts/remove-dst-root-ca-x3.sh /remove-dst-root-ca-x3.sh
-RUN chmod +x /remove-dst-root-ca-x3.sh \
-  && /remove-dst-root-ca-x3.sh \
-  && rm /remove-dst-root-ca-x3.sh
-
-RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / \
-  && rm -rf /tmp/s6-overlay-amd64.tar.gz
-
-RUN groupadd -r usr1cv8 --gid=2001 \
-  && useradd -r -g usr1cv8 --uid=2001 --home-dir=/home/usr1cv8 --shell=/sbin/nologin usr1cv8 \
-  && mkdir -p /home/usr1cv8/.1cv8 \
-  && mkdir -p /home/usr1cv8/.1C/1cestart \
-  && chown -R usr1cv8:usr1cv8 /home/usr1cv8
+    && env DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+        at-spi2-core \
+        dbus-x11 \
+        dirmngr \
+        git \
+        gnupg \
+        iproute2 \
+        procps \
+        psmisc \
+        x11-utils \
+        x11-xserver-utils \
+        x11vnc \
+        xdg-utils \
+        xfce4 \
+        xfce4-goodies \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf \
+    && mkdir -p /root/.gnupg && chmod 700 /root/.gnupg \
+    && chmod +x /tmp/s6-overlay-installer && /tmp/s6-overlay-installer /
 
 COPY ./configs/client-vnc/rootfs/ /
+
+EXPOSE 5900
 
 ENV DISPLAY=:0
 ENV DISPLAY_WIDTH=1440
 ENV DISPLAY_HEIGHT=900
-
-EXPOSE 5900
 
 ENTRYPOINT ["/init"]

--- a/client-vnc/Dockerfile
+++ b/client-vnc/Dockerfile
@@ -1,6 +1,6 @@
-ARG DOCKER_REGISTRY_URL
-ARG ONEC_VERSION
-FROM ${DOCKER_REGISTRY_URL}/onec-client:${ONEC_VERSION} as base
+ARG DOCKER_REGISTRY_URL=localhost:5000
+ARG ONEC_VERSION=8.3.25.1546
+FROM ${DOCKER_REGISTRY_URL}/onec-client:${ONEC_VERSION} AS base
 
 FROM debian:bullseye-slim
 ARG ONEC_VERSION
@@ -11,12 +11,12 @@ ADD https://github.com/just-containers/s6-overlay/releases/download/v1.21.8.0/s6
 
 RUN apt-get update \
   && apt-mark hold iptables \
-  && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  && env DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     dbus-x11 \
     psmisc \
-    xdg-utils \
-    x11-xserver-utils \
     x11-utils \
+    x11-xserver-utils \
+    xdg-utils \
     xvfb \
   && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     xfce4 \
@@ -31,24 +31,23 @@ RUN apt-get update \
   && echo "deb http://security.debian.org/debian-security/ bullseye-security main contrib non-free" >> /etc/apt/sources.list \
   && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
   && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      ca-certificates \
-      git \
-      locales \
-      ttf-mscorefonts-installer \
-      libfontconfig1 \
-      libgsf-1-114 \
-      libglib2.0-0 \
-      libgtk2.0-0 \
-      libodbc1 \
-      libtcmalloc-minimal4 \
-      libmagickwand-6.q16-6 \
-      libwebkit2gtk-4.0-37 \
-      at-spi2-core \
-      procps \
-      x11vnc \
-      iproute2 \
-  # Install libpng12-0 from xenial
+  && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+    at-spi2-core \
+    ca-certificates \
+    git \
+    iproute2 \
+    libfontconfig1 \
+    libglib2.0-0 \
+    libgsf-1-114 \
+    libgtk2.0-0 \
+    libmagickwand-6.q16-6 \
+    libodbc1 \
+    libtcmalloc-minimal4 \
+    libwebkit2gtk-4.0-37 \
+    locales \
+    procps \
+    ttf-mscorefonts-installer \
+    x11vnc \
   && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 40976EAF437D05B5 \
   && echo "deb http://security.ubuntu.com/ubuntu xenial-security main" > /etc/apt/sources.list.d/xenial-security.list \
   && apt-get update \
@@ -67,7 +66,7 @@ RUN apt-get update \
     /var/lib/apt/lists/* \
     /var/cache/debconf \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
-ENV LANG ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
 
 # remove DST Root CA X3 cert if it exists
 COPY ./scripts/remove-dst-root-ca-x3.sh /remove-dst-root-ca-x3.sh

--- a/client-vnc/Dockerfile
+++ b/client-vnc/Dockerfile
@@ -5,9 +5,6 @@ FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG} AS onecclient
 
 ADD https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-amd64-installer /tmp/s6-overlay-installer
 
-ARG onec_uid="999"
-ARG onec_gid="999"
-
 USER root
 
 RUN apt-get update \

--- a/client-vnc/Dockerfile.bak
+++ b/client-vnc/Dockerfile.bak
@@ -1,0 +1,94 @@
+ARG DOCKER_REGISTRY_URL=localhost:5000
+ARG ONEC_VERSION=8.3.25.1546
+FROM ${DOCKER_REGISTRY_URL}/onec-client:${ONEC_VERSION} AS onecclient
+
+FROM debian:bullseye-slim
+ARG ONEC_VERSION
+
+COPY --from=onecclient /opt /opt
+
+ADD https://github.com/just-containers/s6-overlay/releases/download/v1.21.8.0/s6-overlay-amd64.tar.gz /tmp/
+
+RUN apt-get update \
+  && apt-mark hold iptables \
+  && env DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+    dbus-x11 \
+    psmisc \
+    x11-utils \
+    x11-xserver-utils \
+    xdg-utils \
+    xvfb \
+  && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    xfce4 \
+    xfce4-goodies \
+  && sed -i 's%<property name="ThemeName" type="string" value="Xfce"/>%<property name="ThemeName" type="string" value="Raleigh"/>%' /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    dirmngr \
+    gnupg \
+  && echo "deb http://http.debian.net/debian/ bullseye main contrib non-free" > /etc/apt/sources.list \
+  && echo "deb http://http.debian.net/debian/ bullseye-backports main" >> /etc/apt/sources.list \
+  && echo "deb http://http.debian.net/debian/ bullseye-proposed-updates main contrib non-free" >> /etc/apt/sources.list \
+  && echo "deb http://security.debian.org/debian-security/ bullseye-security main contrib non-free" >> /etc/apt/sources.list \
+  && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+    at-spi2-core \
+    ca-certificates \
+    git \
+    iproute2 \
+    libfontconfig1 \
+    libglib2.0-0 \
+    libgsf-1-114 \
+    libgtk2.0-0 \
+    libmagickwand-6.q16-6 \
+    libodbc1 \
+    libtcmalloc-minimal4 \
+    libwebkit2gtk-4.0-37 \
+    locales \
+    procps \
+    ttf-mscorefonts-installer \
+    x11vnc \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 40976EAF437D05B5 \
+  && echo "deb http://security.ubuntu.com/ubuntu xenial-security main" > /etc/apt/sources.list.d/xenial-security.list \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      libpng12-0 \
+  && rm -rf  /etc/apt/sources.list.d/xenial-security.list \
+  && apt-get update \
+  # Install libwebkitgtk from stretch
+  && echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list.d/stretch.list \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    libwebkitgtk-3.0-0 \
+  && rm -rf  /etc/apt/sources.list.d/stretch.list \
+  && apt-get update \
+  && rm -rf  \
+    /var/lib/apt/lists/* \
+    /var/cache/debconf \
+  && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
+
+# remove DST Root CA X3 cert if it exists
+COPY ./scripts/remove-dst-root-ca-x3.sh /remove-dst-root-ca-x3.sh
+RUN chmod +x /remove-dst-root-ca-x3.sh \
+  && /remove-dst-root-ca-x3.sh \
+  && rm /remove-dst-root-ca-x3.sh
+
+RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / \
+  && rm -rf /tmp/s6-overlay-amd64.tar.gz
+
+RUN groupadd -r usr1cv8 --gid=2001 \
+  && useradd -r -g usr1cv8 --uid=2001 --home-dir=/home/usr1cv8 --shell=/sbin/nologin usr1cv8 \
+  && mkdir -p /home/usr1cv8/.1cv8 \
+  && mkdir -p /home/usr1cv8/.1C/1cestart \
+  && chown -R usr1cv8:usr1cv8 /home/usr1cv8
+
+COPY ./configs/client-vnc/rootfs/ /
+
+ENV DISPLAY=:0
+ENV DISPLAY_WIDTH=1440
+ENV DISPLAY_HEIGHT=900
+
+EXPOSE 5900
+
+ENTRYPOINT ["/init"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,8 +1,8 @@
 # Используем базовый образ для скачивания
-ARG DOCKER_REGISTRY_URL
-ARG BASE_IMAGE
-ARG BASE_TAG
-FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG} as downloader
+ARG DOCKER_REGISTRY_URL=localhost:5000
+ARG BASE_IMAGE=oscript-downloader
+ARG BASE_TAG=latest
+FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG} AS downloader
 
 # Копирование скрипта скачивания и локальных дистрибутивов
 COPY ./scripts/download_yard.sh /download.sh
@@ -18,23 +18,23 @@ WORKDIR /tmp
 
 # Установка необходимых пакетов и генерация локали
 RUN apt-get update \
-  && apt-get install -y \
-          locales \
-          p7zip-rar \
-          p7zip-full \
+  && apt-get install --yes \
+    locales \
+    p7zip-full \
+    p7zip-rar \
   && rm -rf /var/lib/apt/lists/* \
   && locale-gen ru_RU.UTF-8 \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 
 # Установка переменных окружения для корректной работы локали
-ENV LANG ru_RU.UTF-8
-ENV LANGUAGE ru_RU:ru
-ENV LC_ALL ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
+ENV LANGUAGE=ru_RU:ru
+ENV LC_ALL=ru_RU.UTF-8
 
 RUN /download.sh "$ONEC_USERNAME" "$ONEC_PASSWORD" "$ONEC_VERSION" "client"
 
 # Начало основной стадии сборки
-FROM ubuntu:18.04 as base
+FROM ubuntu:20.04 AS installedonec
 
 # Копируем скрипты и файлы установки
 ARG ONEC_VERSION
@@ -47,8 +47,8 @@ ENV installer_type=client
 RUN set -xe \
   && chmod 777 -R /tmp \
   && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      libwebkitgtk-3.0-0
+  && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+    libwebkit2gtk-4.0-37
 
 COPY ./scripts/install_new.sh /install.sh
 COPY --from=downloader /tmp/ /tmp/
@@ -67,35 +67,58 @@ RUN chmod +x /create-symlink-to-current-1cv8.sh \
 
 COPY ./configs/client/current/ /opt/1cv8/current/
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="Anton Kvashenkin <anton.jugatsu@gmail.com> (@jugatsu)"
 
 ARG onec_uid="999"
 ARG onec_gid="999"
 
-COPY --from=base /opt /opt
+COPY --from=installedonec /opt /opt
+
+# RUN set -xe \
+#   && chmod 777 -R /tmp \
+#   && apt-get update \
+#   && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
+#   && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+#     ca-certificates \
+#     dbus-x11 \
+#     libfontconfig1 \
+#     libglib2.0-0 \
+#     libgsf-1-114 \
+#     libgtk2.0-0 \
+#     libodbc1 \
+#     libsm6 \
+#     libwebkit2gtk-4.0-37 \
+#     locales \
+#     ttf-mscorefonts-installer \
+#     xvfb \
+#   && rm -rf  \
+#     /var/lib/apt/lists/* \
+#     /var/cache/debconf \
+#   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8 \
+#   && Xvfb :1 -screen 0 1024x768x24 &
 
 RUN set -xe \
   && chmod 777 -R /tmp \
   && apt-get update \
   && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      locales \
-      ca-certificates \
-      libgtk2.0-0 \
-      libwebkitgtk-3.0-0 \
-      ttf-mscorefonts-installer \
-      libfontconfig1 \
-      libgsf-1-114 \
-      libglib2.0-0 \
-      libodbc1 \
-      libmagickwand-6.q16-3 \
-      dbus-x11 \
-  && rm -rf  \
-    /var/lib/apt/lists/* \
-    /var/cache/debconf \
+  && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+    ca-certificates \
+    dbus-x11 \
+    libfontconfig1 \
+    libglib2.0-0 \
+    libgsf-1-114 \
+    libgtk2.0-0 \
+    libodbc1 \
+    libsm6 \
+    libwebkit2gtk-4.0-37 \
+    locales \
+    ttf-mscorefonts-installer \
+    xvfb \
+  && rm -rf /var/lib/apt/lists/* /var/cache/debconf \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
-ENV LANG ru_RU.UTF-8
+
+ENV LANG=ru_RU.UTF-8
 
 RUN groupadd -r grp1cv8 --gid=$onec_gid \
   && useradd -r -g grp1cv8 --uid=$onec_uid --home-dir=/home/usr1cv8 --shell=/bin/bash usr1cv8 \
@@ -104,6 +127,14 @@ RUN groupadd -r grp1cv8 --gid=$onec_gid \
 
 VOLUME /home/usr1cv8/.1cv8/
 
+COPY ./client/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN ln -s /usr/local/bin/docker-entrypoint.sh / \
+  && chmod +x /usr/local/bin/docker-entrypoint.sh \
+  && mkdir -p /tmp/.X11-unix \
+  && chmod 1777 -R /tmp
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 USER usr1cv8
 
-CMD ["/opt/1C/v8.3/x86_64/1cv8"]
+CMD ["1cv8"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -34,7 +34,7 @@ ENV LC_ALL=ru_RU.UTF-8
 RUN /download.sh "$ONEC_USERNAME" "$ONEC_PASSWORD" "$ONEC_VERSION" "client"
 
 # Начало основной стадии сборки
-FROM ubuntu:20.04 AS installedonec
+FROM ubuntu:20.04 AS onecclient
 
 # Копируем скрипты и файлы установки
 ARG ONEC_VERSION
@@ -45,10 +45,7 @@ ENV distrPath=/tmp/downloads/Platform83/${ONEC_VERSION}
 ENV installer_type=client
 
 RUN set -xe \
-  && chmod 777 -R /tmp \
-  && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-    libwebkit2gtk-4.0-37
+  && chmod 777 -R /tmp
 
 COPY ./scripts/install_new.sh /install.sh
 COPY --from=downloader /tmp/ /tmp/
@@ -73,30 +70,7 @@ LABEL maintainer="Anton Kvashenkin <anton.jugatsu@gmail.com> (@jugatsu)"
 ARG onec_uid="999"
 ARG onec_gid="999"
 
-COPY --from=installedonec /opt /opt
-
-# RUN set -xe \
-#   && chmod 777 -R /tmp \
-#   && apt-get update \
-#   && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
-#   && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
-#     ca-certificates \
-#     dbus-x11 \
-#     libfontconfig1 \
-#     libglib2.0-0 \
-#     libgsf-1-114 \
-#     libgtk2.0-0 \
-#     libodbc1 \
-#     libsm6 \
-#     libwebkit2gtk-4.0-37 \
-#     locales \
-#     ttf-mscorefonts-installer \
-#     xvfb \
-#   && rm -rf  \
-#     /var/lib/apt/lists/* \
-#     /var/cache/debconf \
-#   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8 \
-#   && Xvfb :1 -screen 0 1024x768x24 &
+COPY --from=onecclient /opt /opt
 
 RUN set -xe \
   && chmod 777 -R /tmp \
@@ -104,17 +78,18 @@ RUN set -xe \
   && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
   && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
     ca-certificates \
-    dbus-x11 \
     libfontconfig1 \
     libglib2.0-0 \
     libgsf-1-114 \
     libgtk2.0-0 \
+    libmagickwand-6.q16-6 \
     libodbc1 \
     libsm6 \
     libwebkit2gtk-4.0-37 \
     locales \
     ttf-mscorefonts-installer \
     xvfb \
+  && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/* /var/cache/debconf \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 
@@ -123,6 +98,7 @@ ENV LANG=ru_RU.UTF-8
 RUN groupadd -r grp1cv8 --gid=$onec_gid \
   && useradd -r -g grp1cv8 --uid=$onec_uid --home-dir=/home/usr1cv8 --shell=/bin/bash usr1cv8 \
   && mkdir -p /home/usr1cv8/.1cv8 \
+  && mkdir -p /home/usr1cv8/.1C/1cestart \
   && chown -R usr1cv8:grp1cv8 /home/usr1cv8
 
 VOLUME /home/usr1cv8/.1cv8/
@@ -132,6 +108,10 @@ RUN ln -s /usr/local/bin/docker-entrypoint.sh / \
   && chmod +x /usr/local/bin/docker-entrypoint.sh \
   && mkdir -p /tmp/.X11-unix \
   && chmod 1777 -R /tmp
+
+ENV DISPLAY=:0
+ENV DISPLAY_WIDTH=1440
+ENV DISPLAY_HEIGHT=900
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 

--- a/client/docker-entrypoint.sh
+++ b/client/docker-entrypoint.sh
@@ -3,8 +3,7 @@
 PATH="/opt/1cv8/current:$PATH"
 
 # Запускаем Xvfb в фоновом режиме, надо для 1cv8, 1cv8c или 1cv8s
-Xvfb :1 -screen 0 1024x768x24 &
-export DISPLAY=:1
+Xvfb $DISPLAY -screen 0 ${DISPLAY_WIDTH}x${DISPLAY_HEIGHT}x24 &
 
 # Запускаем переданную команду
 exec "$@"

--- a/client/docker-entrypoint.sh
+++ b/client/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+PATH="/opt/1cv8/current:$PATH"
+
+# Запускаем Xvfb в фоновом режиме, надо для 1cv8, 1cv8c или 1cv8s
+Xvfb :1 -screen 0 1024x768x24 &
+export DISPLAY=:1
+
+# Запускаем переданную команду
+exec "$@"

--- a/configs/client-vnc/rootfs/etc/services.d/x11vnc/run
+++ b/configs/client-vnc/rootfs/etc/services.d/x11vnc/run
@@ -1,3 +1,5 @@
 #!/usr/bin/with-contenv sh
 
-exec /usr/bin/x11vnc -q -forever -shared -nomodtweak -capslock -display $DISPLAY
+echo "Starting /usr/bin/x11vnc jn display $DISPLAY"
+
+exec x11vnc -q -forever -shared -nomodtweak -capslock -display $DISPLAY

--- a/configs/client-vnc/rootfs/etc/services.d/xfce/run
+++ b/configs/client-vnc/rootfs/etc/services.d/xfce/run
@@ -4,4 +4,6 @@
 mkdir -p /root/.config/xfce4/xfconf/xfce-perchannel-xml
 cp /etc/xdg/xfce4/panel/default.xml ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
 
+echo "Starting startxfce4 current path: $PATH"
+
 exec startxfce4

--- a/configs/client-vnc/rootfs/etc/services.d/xvfb/run
+++ b/configs/client-vnc/rootfs/etc/services.d/xvfb/run
@@ -1,3 +1,5 @@
 #!/usr/bin/with-contenv sh
 
-exec /usr/bin/Xvfb $DISPLAY -screen 0 ${DISPLAY_WIDTH}x${DISPLAY_HEIGHT}x24
+echo "Starting Xvfb display $DISPLAY ${DISPLAY_WIDTH}x${DISPLAY_HEIGHT}x24"
+
+exec Xvfb $DISPLAY -screen 0 ${DISPLAY_WIDTH}x${DISPLAY_HEIGHT}x24

--- a/configs/pusk/rootfs/etc/services.d/ite-pusk/run
+++ b/configs/pusk/rootfs/etc/services.d/ite-pusk/run
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Starting PUSK"
+cd /opt/pusk/bin
+java -cp ite-pusk.jar:/opt/pusk/lib/* -Dloader.main=com.ite.utils.pusk.Application \
+    org.springframework.boot.loader.PropertiesLauncher --spring.config.import=optional:/opt/pusk/data/application.properties >> /opt/pusk/log/java.log

--- a/coverage41C/Dockerfile
+++ b/coverage41C/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_TAG
 ARG EDT_VERSION=2021.3
 ARG COVERAGE41C_VERSION=2.7.3
 
-FROM ${DOCKER_REGISTRY_URL}/edt:${EDT_VERSION} as base
+FROM ${DOCKER_REGISTRY_URL}/edt:${EDT_VERSION} AS installededt
 
 RUN ln -s $(find /opt/1C -name "com._1c.g5.v8.dt.debug.*.jar" -printf '%h\n'| sort -u) /opt/1C/edt_plugins
 
@@ -13,7 +13,7 @@ LABEL maintainer="Dima Ovcharenko <d.ovcharenko90@gmail.com>, Korus Consulting L
 
 ARG COVERAGE41C_VERSION
 
-COPY --from=base /opt/1C/edt_plugins/com._1c.g5.v8.dt.debug.core_*.jar /opt/1C/edt_plugins/com._1c.g5.v8.dt.debug.model_*.jar /opt/1C/1CE/
+COPY --from=installededt /opt/1C/edt_plugins/com._1c.g5.v8.dt.debug.core_*.jar /opt/1C/edt_plugins/com._1c.g5.v8.dt.debug.model_*.jar /opt/1C/1CE/
 
 ADD https://github.com/1c-syntax/Coverage41C/releases/download/v${COVERAGE41C_VERSION}/Coverage41C-${COVERAGE41C_VERSION}.tar \
     /opt/

--- a/crs-apache/1crs.conf
+++ b/crs-apache/1crs.conf
@@ -1,8 +1,8 @@
 LoadModule _1cws_module /opt/1cv8/current/wsap24.so
 AddHandler 1cws-process .1ccr
 
-Alias /repo "/home/usr1cv8/.1cv8"
-<Directory "/home/usr1cv8/.1cv8">
+Alias /crs "/home/usr1cv8/.1cv8/crsweb"
+<Directory "/home/usr1cv8/.1cv8/crsweb">
     AllowOverride All
     Require all granted
     Order allow,deny

--- a/crs-apache/Dockerfile
+++ b/crs-apache/Dockerfile
@@ -1,29 +1,25 @@
-ARG DOCKER_REGISTRY_URL
-ARG ONEC_VERSION
+ARG DOCKER_REGISTRY_URL=localhost:5000
+ARG ONEC_VERSION=8.3.25.1546
 
 FROM ${DOCKER_REGISTRY_URL}/crs:${ONEC_VERSION}
 
-ARG REPO_DIR=/home/usr1cv8/.1cv8/repo
-
 RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+  && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     apache2 \
-  && rm -rf  \
-    /var/lib/apt/lists/* \
-    /var/cache/debconf \
-    /tmp/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/debconf
 
 COPY ./crs-apache/1crs.conf /etc/apache2/conf-available/
-RUN ln -s /etc/apache2/conf-available/1crs.conf /etc/apache2/conf-enabled/1crs.conf
-RUN echo "export APACHE_RUN_DIR=/etc/apache2\$SUFFIX" >> /etc/apache2/envvars \
+RUN ln -s /etc/apache2/conf-available/1crs.conf /etc/apache2/conf-enabled/1crs.conf \
+  && echo "export APACHE_RUN_DIR=/etc/apache2\$SUFFIX" >> /etc/apache2/envvars \
   && echo "export APACHE_PID_FILE=/etc/apache2\$SUFFIX/apache2.pid" >> /etc/apache2/envvars 
 
-COPY ./crs-apache/repo.1ccr /home/usr1cv8/.1cv8
-RUN mkdir -p ${REPO_DIR}
+COPY ./crs-apache/repo.1ccr /home/usr1cv8/.1cv8/crsweb/
 
 COPY ./crs-apache/docker-entrypoint.sh /
 RUN chmod 755 /docker-entrypoint.sh \
   && chmod +x /docker-entrypoint.sh
+
+VOLUME /home/usr1cv8/.1cv8/crs
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/crs-apache/README.md
+++ b/crs-apache/README.md
@@ -1,19 +1,13 @@
-# Сервер хранилища + Apache 2.4
+# Сервер хранилища + Apache 2
 
-Монтирование хранилищ внутрь каталога:
+Пример запуска:
 
+в каталоге `C:\Temp\crs` - разные хранилища, например есть `C:\Temp\crs\sample-svn`
 ```
-/home/usr1cv8/.1cv8
-```
-
-Например:
-
-```
--v ./my_depot:/home/usr1cv8/.1cv8/repo/my_depot
+docker run --rm -v "C:\Temp\crs:/home/usr1cv8/.1cv8/crs" -p 1548:80 localhost:5000/crs-apache:8.3.25.1546
 ```
 
 Доступ к хранилищу:
-
 ```
-http://localhost:8080/repo/repo.1ccr/my_depot
+http://localhost:1548/crs/repo.1ccr/sample-svn
 ```

--- a/crs-apache/docker-entrypoint.sh
+++ b/crs-apache/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # start crserver
-exec gosu usr1cv8 /opt/1cv8/current/crserver -port 1542 -d /home/usr1cv8/.1cv8/repo -daemon &
+exec gosu usr1cv8 /opt/1cv8/current/crserver -port 1542 -d /home/usr1cv8/.1cv8/crs -daemon &
 
 # start apache2
 source /etc/apache2/envvars

--- a/crs/Dockerfile
+++ b/crs/Dockerfile
@@ -1,85 +1,21 @@
-FROM alpine:latest AS downloader
+ARG DOCKER_REGISTRY_URL=localhost:5000
+ARG BASE_IMAGE=onec-server
+ARG BASE_TAG=8.3.25.1546
+FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG} AS onecserver
 
-ARG ONEC_USERNAME
-ARG ONEC_PASSWORD
-ARG ONEC_VERSION
-ENV installer_type=server32
-ENV downloads=downloads/platform83/${ONEC_VERSION}
+ADD https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64 /bin/gosu
 
-COPY ./scripts/download_og.sh /download_og.sh
+RUN chmod +x /bin/gosu \
+    && mkdir -p /home/usr1cv8/.1cv8/crs \
+    && chown -R usr1cv8:grp1cv8 /var/log/1C /home/usr1cv8
 
-WORKDIR /tmp
-COPY ./distr ./${downloads}
-RUN rm ./${downloads}/.gitkeep \
-  && rm -rf ${downloads}/thin.client*.tar.gz \
-  && rm -rf ${downloads}/client*.tar.gz \
-  && rm -rf ${downloads}/1c_edt*.tar.gz \
-  && if [ -z "$(ls -A ${downloads})" ]; then \
-  apk --no-cache add bash curl grep tar \
-  && set -x \
-  && sync; /download_og.sh; \
-  fi \
-  && rm -rf ${downloads}/*thin*.tar.gz \
-  && ls ${downloads} \
-  && for file in ${downloads}/*.tar.gz; do tar -xzf "$file"; done \
-  && rm -rf ${downloads}/*.*
+COPY ./crs/docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh \
+  && chmod +x /opt/1cv8/current/crserver
 
-FROM i386/debian:bullseye-slim AS base
+VOLUME /home/usr1cv8/.1cv8/crs
 
-ARG gosu_ver=1.11
-ARG ONEC_VERSION
-ARG nls_enabled=false
-ENV installer_type=server32
-ENV nls=$nls_enabled
-
-COPY ./scripts/install.sh /install.sh
-COPY --from=downloader /tmp/*.* /tmp/
-WORKDIR /tmp
-
-SHELL ["/bin/bash", "-c"]
-RUN ls . \
-  && chmod +x /install.sh \
-  && sync; /install.sh
-
-# create symlink to current 1c:enterprise directory
-COPY ./scripts/create-symlink-to-current-1cv8.sh /create-symlink-to-current-1cv8.sh
-RUN chmod +x /create-symlink-to-current-1cv8.sh \
-  && /create-symlink-to-current-1cv8.sh \
-  && rm /create-symlink-to-current-1cv8.sh
-
-ADD https://github.com/tianon/gosu/releases/download/$gosu_ver/gosu-i386 /bin/gosu
-
-RUN chmod +x /bin/gosu
-
-FROM i386/debian:bullseye-slim
-LABEL maintainer="Anton Kvashenkin <anton.jugatsu@gmail.com> (@jugatsu)"
-
-ARG onec_uid="999"
-ARG onec_gid="999"
-
-COPY --from=base /opt /opt
-COPY --from=base /bin/gosu /bin/gosu
-
-RUN set -xe \
-  && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      locales \
-  && rm -rf \
-    /var/lib/apt/lists/* \
-    /var/cache/debconf \
-  && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
-ENV LANG=ru_RU.UTF-8
-
-RUN groupadd -r grp1cv8 --gid=$onec_gid \
-  && useradd -r -g grp1cv8 --uid=$onec_uid --home-dir=/home/usr1cv8 --shell=/bin/bash usr1cv8 \
-  && mkdir -p /home/usr1cv8/.1cv8 \
-  && chown -R usr1cv8:grp1cv8 /home/usr1cv8
-
-VOLUME /home/usr1cv8/.1cv8
-
-COPY ./crs/docker-entrypoint.sh /usr/local/bin
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 1542
 CMD ["crserver"]

--- a/crs/Dockerfile
+++ b/crs/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest as downloader
+FROM alpine:latest AS downloader
 
 ARG ONEC_USERNAME
 ARG ONEC_PASSWORD
@@ -24,7 +24,7 @@ RUN rm ./${downloads}/.gitkeep \
   && for file in ${downloads}/*.tar.gz; do tar -xzf "$file"; done \
   && rm -rf ${downloads}/*.*
 
-FROM i386/debian:bullseye-slim as base
+FROM i386/debian:bullseye-slim AS base
 
 ARG gosu_ver=1.11
 ARG ONEC_VERSION
@@ -68,7 +68,7 @@ RUN set -xe \
     /var/lib/apt/lists/* \
     /var/cache/debconf \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
-ENV LANG ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
 
 RUN groupadd -r grp1cv8 --gid=$onec_gid \
   && useradd -r -g grp1cv8 --uid=$onec_uid --home-dir=/home/usr1cv8 --shell=/bin/bash usr1cv8 \

--- a/crs/Dockerfile.bak
+++ b/crs/Dockerfile.bak
@@ -1,0 +1,85 @@
+FROM alpine:latest AS downloader
+
+ARG ONEC_USERNAME
+ARG ONEC_PASSWORD
+ARG ONEC_VERSION
+ENV installer_type=server32
+ENV downloads=downloads/platform83/${ONEC_VERSION}
+
+COPY ./scripts/download_og.sh /download_og.sh
+
+WORKDIR /tmp
+COPY ./distr ./${downloads}
+RUN rm ./${downloads}/.gitkeep \
+  && rm -rf ${downloads}/thin.client*.tar.gz \
+  && rm -rf ${downloads}/client*.tar.gz \
+  && rm -rf ${downloads}/1c_edt*.tar.gz \
+  && if [ -z "$(ls -A ${downloads})" ]; then \
+  apk --no-cache add bash curl grep tar \
+  && set -x \
+  && sync; /download_og.sh; \
+  fi \
+  && rm -rf ${downloads}/*thin*.tar.gz \
+  && ls ${downloads} \
+  && for file in ${downloads}/*.tar.gz; do tar -xzf "$file"; done \
+  && rm -rf ${downloads}/*.*
+
+FROM i386/debian:bullseye-slim AS base
+
+ARG gosu_ver=1.11
+ARG ONEC_VERSION
+ARG nls_enabled=false
+ENV installer_type=server32
+ENV nls=$nls_enabled
+
+COPY ./scripts/install.sh /install.sh
+COPY --from=downloader /tmp/*.* /tmp/
+WORKDIR /tmp
+
+SHELL ["/bin/bash", "-c"]
+RUN ls . \
+  && chmod +x /install.sh \
+  && sync; /install.sh
+
+# create symlink to current 1c:enterprise directory
+COPY ./scripts/create-symlink-to-current-1cv8.sh /create-symlink-to-current-1cv8.sh
+RUN chmod +x /create-symlink-to-current-1cv8.sh \
+  && /create-symlink-to-current-1cv8.sh \
+  && rm /create-symlink-to-current-1cv8.sh
+
+ADD https://github.com/tianon/gosu/releases/download/$gosu_ver/gosu-i386 /bin/gosu
+
+RUN chmod +x /bin/gosu
+
+FROM i386/debian:bullseye-slim
+LABEL maintainer="Anton Kvashenkin <anton.jugatsu@gmail.com> (@jugatsu)"
+
+ARG onec_uid="999"
+ARG onec_gid="999"
+
+COPY --from=base /opt /opt
+COPY --from=base /bin/gosu /bin/gosu
+
+RUN set -xe \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      locales \
+  && rm -rf \
+    /var/lib/apt/lists/* \
+    /var/cache/debconf \
+  && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
+
+RUN groupadd -r grp1cv8 --gid=$onec_gid \
+  && useradd -r -g grp1cv8 --uid=$onec_uid --home-dir=/home/usr1cv8 --shell=/bin/bash usr1cv8 \
+  && mkdir -p /home/usr1cv8/.1cv8 \
+  && chown -R usr1cv8:grp1cv8 /home/usr1cv8
+
+VOLUME /home/usr1cv8/.1cv8
+
+COPY ./crs/docker-entrypoint.sh /usr/local/bin
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 1542
+CMD ["crserver"]

--- a/crs/docker-entrypoint.sh
+++ b/crs/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" = "crserver" ]; then
-  exec gosu usr1cv8 /opt/1cv8/current/crserver -port 1542 -d /home/usr1cv8/.1cv8
+  exec gosu usr1cv8 /opt/1cv8/current/crserver -port 1542 -d /home/usr1cv8/.1cv8/crs
 fi
 
 exec "$@"

--- a/edt/Dockerfile
+++ b/edt/Dockerfile
@@ -1,13 +1,12 @@
 # Используем базовый образ для скачивания
-ARG DOWNLOADER_REGISTRY_URL
-ARG DOWNLOADER_IMAGE
-ARG DOWNLOADER_TAG
+ARG DOCKER_REGISTRY_URL=localhost:5000
+ARG DOWNLOADER_IMAGE=oscript-downloader
+ARG DOWNLOADER_TAG=latest
 
 ARG BASE_IMAGE=eclipse-temurin
 ARG BASE_TAG=11
-ARG DOCKER_REGISTRY_URL=library
 
-FROM ${DOWNLOADER_REGISTRY_URL}/${DOWNLOADER_IMAGE}:${DOWNLOADER_TAG} as downloader
+FROM ${DOCKER_REGISTRY_URL}/${DOWNLOADER_IMAGE}:${DOWNLOADER_TAG} AS downloader
 
 # Копирование скрипта скачивания и локальных дистрибутивов
 COPY ./scripts/download_yard.sh /download.sh
@@ -23,20 +22,21 @@ WORKDIR /tmp
 
 # Установка необходимых пакетов и генерация локали
 RUN apt-get update \
-  && apt-get install -y \
-          locales \
-          p7zip-rar \
-          p7zip-full \
+  && apt-get install --yes \
+    locales \
+    p7zip-full \
+    p7zip-rar \
   && rm -rf /var/lib/apt/lists/* \
   && locale-gen ru_RU.UTF-8 \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 
 # Установка переменных окружения для корректной работы локали
-ENV LANG ru_RU.UTF-8
-ENV LANGUAGE ru_RU:ru
-ENV LC_ALL ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
+ENV LANGUAGE=ru_RU:ru
+ENV LC_ALL=ru_RU.UTF-8
 
 RUN /download.sh "$ONEC_USERNAME" "$ONEC_PASSWORD" "$EDT_VERSION" "edt"
+
 
 FROM ${BASE_IMAGE}:${BASE_TAG}
 
@@ -46,9 +46,7 @@ WORKDIR /tmp
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-    # downloader dependencies
     curl \
-    # edt dependencies
     libgtk-3-0 \
     locales \
   && rm -rf  \
@@ -61,9 +59,9 @@ ARG EDT_VERSION=2021.3
 ARG downloads=downloads/DevelopmentTools10/${EDT_VERSION}
 
 # Установка переменных окружения для корректной работы локали
-ENV LANG ru_RU.UTF-8
-ENV LANGUAGE ru_RU:ru
-ENV LC_ALL ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
+ENV LANGUAGE=ru_RU:ru
+ENV LC_ALL=ru_RU.UTF-8
 
 # Install EDT
 COPY --from=downloader /tmp/${downloads} /tmp/${downloads}
@@ -75,6 +73,8 @@ RUN chmod +x ./1ce-installer-cli \
   && rm -rf /tmp/* \
   && mv $(dirname $(find /opt/1C/1CE -name ring)) /opt/1C/1CE/components/1c-enterprise-ring \
   #1cedtcli отсутствует в EDT версии <2023.1.0
-  && if [ -n "$(find /opt/1C/1CE -name 1cedtcli)" ]; then mv $(dirname $(find /opt/1C/1CE -name 1cedtcli)) /opt/1C/1CE/components/1cedtcli; fi
+  && { if [ -n "$(find /opt/1C/1CE -name 1cedtcli)" ]; then \
+      mv $(dirname $(find /opt/1C/1CE -name 1cedtcli)) /opt/1C/1CE/components/1cedtcli; \
+    fi }
 
 ENV PATH="/opt/1C/1CE/components/1c-enterprise-ring:/opt/1C/1CE/components/1cedtcli:$PATH"

--- a/gitsync/Dockerfile
+++ b/gitsync/Dockerfile
@@ -1,13 +1,13 @@
 ARG DOCKER_REGISTRY_URL
 ARG ONEC_VERSION
-FROM ${DOCKER_REGISTRY_URL}/onec-client:${ONEC_VERSION} as base
+FROM ${DOCKER_REGISTRY_URL}/onec-client:${ONEC_VERSION} AS installedonec
 
 FROM mono:5.20-slim
 LABEL maintainer="Anton Kvashenkin <anton.jugatsu@gmail.com> (@jugatsu)"
 
 ARG gitsync_ver=3.0.0
 
-COPY --from=base /opt /opt
+COPY --from=installedonec /opt /opt
 
 RUN echo "deb http://http.debian.net/debian/ stretch main contrib non-free" > /etc/apt/sources.list.d/stretch.list \
   && echo "deb http://http.debian.net/debian/ stretch-updates main contrib non-free" >> > /etc/apt/sources.list.d/stretch-updates.list \
@@ -15,18 +15,18 @@ RUN echo "deb http://http.debian.net/debian/ stretch main contrib non-free" > /e
   && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      ca-certificates \
-      git \
-      locales \
-      libwebkitgtk-3.0-0 \
-      ttf-mscorefonts-installer \
-      libfontconfig1 \
-      libgsf-1-114 \
-      libglib2.0-0 \
-      libodbc1 \
-      libmagickwand-6.q16-3 \
-      libmono-system-runtime-serialization4.0-cil \
-      dbus-x11 \
+    ca-certificates \
+    dbus-x11 \
+    git \
+    libfontconfig1 \
+    libglib2.0-0 \
+    libgsf-1-114 \
+    libmagickwand-6.q16-3 \
+    libmono-system-runtime-serialization4.0-cil \
+    libodbc1 \
+    libwebkitgtk-3.0-0 \
+    locales \
+    ttf-mscorefonts-installer \
   && rm -rf \
     /etc/apt/sources.list.d/stretch.list \
     /etc/apt/sources.list.d/stretch-updates.list \
@@ -36,7 +36,7 @@ RUN echo "deb http://http.debian.net/debian/ stretch main contrib non-free" > /e
     /var/lib/apt/lists/* \
     /var/cache/debconf \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
-ENV LANG ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
 
 ADD https://github.com/oscript-library/gitsync/releases/download/$gitsync_ver/gitsync.exe /gitsync.exe
 

--- a/gitsync/Dockerfile
+++ b/gitsync/Dockerfile
@@ -1,13 +1,13 @@
 ARG DOCKER_REGISTRY_URL
 ARG ONEC_VERSION
-FROM ${DOCKER_REGISTRY_URL}/onec-client:${ONEC_VERSION} AS installedonec
+FROM ${DOCKER_REGISTRY_URL}/onec-client:${ONEC_VERSION} AS onecclient
 
 FROM mono:5.20-slim
 LABEL maintainer="Anton Kvashenkin <anton.jugatsu@gmail.com> (@jugatsu)"
 
 ARG gitsync_ver=3.0.0
 
-COPY --from=installedonec /opt /opt
+COPY --from=onecclient /opt /opt
 
 RUN echo "deb http://http.debian.net/debian/ stretch main contrib non-free" > /etc/apt/sources.list.d/stretch.list \
   && echo "deb http://http.debian.net/debian/ stretch-updates main contrib non-free" >> > /etc/apt/sources.list.d/stretch-updates.list \

--- a/jdk/Dockerfile
+++ b/jdk/Dockerfile
@@ -9,21 +9,24 @@ LABEL maintainer="Nikita Gryzlov <NikGryzlov@1bit.com>, FirstBit"
 # Install OpenJDK
 ARG OPENJDK_VERSION=17
 
+ADD https://packages.adoptium.net/artifactory/api/gpg/key/public /etc/apt/keyrings/adoptium.asc
 RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      apt-transport-https \
-      ca-certificates \
-      git \
-      gnupg \
-      dirmngr \
-      locales \
-      software-properties-common \
-      wget \
+  && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    dirmngr \
+    git \
+    gnupg \
+    locales \
+    software-properties-common \
+    wget \
   && mkdir -p /etc/apt/keyrings \
-  && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
   && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
   && apt update \
   && apt install -y temurin-${OPENJDK_VERSION}-jdk \
+  && rm -rf  \
+  /var/lib/apt/lists/* \
+  /var/cache/debconf \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 
 # remove DST Root CA X3 cert if it exists
@@ -32,4 +35,4 @@ RUN chmod +x /remove-dst-root-ca-x3.sh \
   && /remove-dst-root-ca-x3.sh \
   && rm /remove-dst-root-ca-x3.sh
 
-ENV LANG ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8

--- a/k8s-jenkins-agent/Dockerfile
+++ b/k8s-jenkins-agent/Dockerfile
@@ -1,10 +1,10 @@
 # Для сборки использован стандартный шаблон jenkins-inbound-agent https://github.com/jenkinsci/docker-agent/blob/master/debian/Dockerfile
-# Стадию с as jre-build убрал, т.к. у нас на этот момент уже всегда есть джава в контейнере.
+# Стадию с AS jre-build убрал, т.к. у нас на этот момент уже всегда есть джава в контейнере.
 ARG DOCKER_REGISTRY_URL
 ARG BASE_IMAGE
 ARG BASE_TAG
 
-FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG} as agent
+FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG} AS agent
 
 LABEL maintainer="Nikita Gryzlov <NikGryzlov@1bit.com>, FirstBit"
 

--- a/pusk/Dockerfile
+++ b/pusk/Dockerfile
@@ -1,0 +1,44 @@
+FROM bellsoft/liberica-openjdk-debian:17
+
+ADD https://it-expertise.ru/pusk/ite-pusk-1.2.1.tar.gz /tmp/
+ADD https://its.1c.ru/db/files/1CITS/EXE/java-api-8.3.11/java-api-8.3.11.zip /tmp/
+ADD https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-amd64-installer /tmp/s6-overlay-installer
+
+COPY ./configs/pusk/rootfs/ /
+
+RUN apt-get update \
+  && apt-get install --yes \
+    locales \
+    procps \
+    unzip \
+  && rm -rf /var/lib/apt/lists/* \
+  && locale-gen ru_RU.UTF-8 \
+  && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8 \
+  && tar xzf /tmp/ite-pusk-1.2.1.tar.gz -C /opt/ \
+  && rm -rf /tmp/ite-pusk-1.2.1.tar.gz \
+  && chmod +x /opt/pusk/ite-pusk-linux.sh \
+  && ln -s /usr/lib/jvm/jdk-17.0.14-bellsoft-x86_64/bin/java /usr/bin/java \
+  && unzip /tmp/java-api-8.3.11.zip -d /tmp/ \
+  && rm -rf /tmp/java-api-8.3.11.zip \
+  && unzip /tmp/java-api-8.3.11/java-api-1.6.7.zip -d /tmp/ \
+  && rm -rf /tmp/java-api-8.3.11/java-api-1.6.7.zip \
+  && unzip /tmp/java-api-1.6.7/com._1c.v8.ibis.admin-1.6.7.zip -d /tmp/ \
+  && rm -rf /tmp/java-api-1.6.7/com._1c.v8.ibis.admin-1.6.7.zip \
+  && mv /tmp/com._1c.v8.ibis.admin-1.6.7/lib/* /opt/pusk/lib/ \
+  && chmod +x /tmp/s6-overlay-installer && /tmp/s6-overlay-installer / \
+  && echo '#!/bin/bash\n echo "systemd (systemctl) is not available in this container."\n exit 0' > /usr/local/bin/systemctl \
+  && chmod +x /usr/local/bin/systemctl \
+  && ln -s /usr/local/bin/systemctl /bin/systemctl
+
+ENV LANG=ru_RU.UTF-8
+ENV LANGUAGE=ru_RU:ru
+ENV LC_ALL=ru_RU.UTF-8
+
+VOLUME /opt/pusk/data
+VOLUME /opt/pusk/log
+
+EXPOSE 8080
+
+WORKDIR /opt/pusk
+
+ENTRYPOINT ["/init"]

--- a/pusk/application.properties.example
+++ b/pusk/application.properties.example
@@ -1,0 +1,36 @@
+#Порт запуска консоли
+server.port=${PORT:8080}
+
+#Путь создания файла config.json
+config.file.path=../data
+
+#Уровень логирования. Возможные варианты: OFF, FATAl, ERROR, WARN, INFO, DEBUG, TRACE, ALL
+logging.level.config=FATAl
+#Путь к каталогу для сохранения файлов логов
+logging.file.path=../log
+#Имя файла логов
+logging.file.name=info
+#Паттерн вывода сообщения в логи
+logging.pattern.file=%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+#Общий размер логов
+logging.total-size-cap=500MB
+#Количество дней хранения логов
+logging.max-history-days=7
+
+#Если задано значение 'true', отправка логов в файл выключится и включится отправка в syslog
+send.log.to.syslog=false
+#Адрес syslog
+syslog.host=localhost
+#Идентификации источника сообщения. Возможные варианты:KERN, USER, MAIL, DAEMON, AUTH, SYSLOG, LPR, NEWS, UUCP, CRON, AUTHPRIV, FTP, NTP, AUDIT, ALERT, CLOCK, LOCAL0, LOCAL1, LOCAL2, LOCAL3, LOCAL4, LOCAL5, LOCAL6, LOCAL7
+syslog.facility=LOCAL0
+
+#Алгоритм шифрования паролей
+cryptography.algorithm=AES
+#Ключ шифрования паролей
+cryptography.key=A134E8FF3F982HD:
+
+#Соль для хеширования учетных данных пользователей ПУСК
+security.salt=1jhjg2ddx3wqe12asdad1:
+
+#Настройка проверки сложности пароля
+check.password.strength=true

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,8 +1,8 @@
 # Используем базовый образ для скачивания
-ARG DOCKER_REGISTRY_URL
-ARG BASE_IMAGE
-ARG BASE_TAG
-FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG} as downloader
+ARG DOCKER_REGISTRY_URL=localhost:5000
+ARG BASE_IMAGE=oscript-downloader
+ARG BASE_TAG=latest
+FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG} AS downloader
 
 # Копирование скрипта скачивания и локальных дистрибутивов
 COPY ./scripts/download_yard.sh /download.sh
@@ -18,23 +18,23 @@ WORKDIR /tmp
 
 # Установка необходимых пакетов и генерация локали
 RUN apt-get update \
-  && apt-get install -y \
-          locales \
-          p7zip-rar \
-          p7zip-full \
+  && apt-get install --yes \
+    locales \
+    p7zip-full \
+    p7zip-rar \
   && rm -rf /var/lib/apt/lists/* \
   && locale-gen ru_RU.UTF-8 \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 
 # Установка переменных окружения для корректной работы локали
-ENV LANG ru_RU.UTF-8
-ENV LANGUAGE ru_RU:ru
-ENV LC_ALL ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
+ENV LANGUAGE=ru_RU:ru
+ENV LC_ALL=ru_RU.UTF-8
 
 RUN /download.sh "$ONEC_USERNAME" "$ONEC_PASSWORD" "$ONEC_VERSION" "server"
 
 # Начало основной стадии сборки
-FROM ubuntu:20.04 as installer
+FROM ubuntu:20.04 AS installer
 
 # Копируем скрипты и файлы установки
 ARG ONEC_VERSION
@@ -46,20 +46,20 @@ ENV installer_type=server
 
 # Установка зависимостей и настройка локали
 RUN apt-get update \
-&& apt-get install -yq \
-      procps \
-      tzdata \
-      debconf-utils \
-      curl \
-      fontconfig \
-      unixodbc \
-      ttf-mscorefonts-installer \
-      libgsf-1-114 \
-      keyboard-configuration \
-&& dpkg-reconfigure -f noninteractive tzdata \
-&& dpkg-reconfigure -f noninteractive keyboard-configuration \
-&& apt-get install -yq geoclue-2.0 gstreamer1.0-plugins-bad \
-&& export LANG=ru_RU.UTF-8
+  && apt-get install --yes --quiet \
+    curl \
+    debconf-utils \
+    fontconfig \
+    keyboard-configuration \
+    libgsf-1-114 \
+    procps \
+    ttf-mscorefonts-installer \
+    tzdata \
+    unixodbc \
+  && dpkg-reconfigure -f noninteractive tzdata \
+  && dpkg-reconfigure -f noninteractive keyboard-configuration \
+  && apt-get install -yq geoclue-2.0 gstreamer1.0-plugins-bad \
+  && export LANG=ru_RU.UTF-8
 
 COPY ./scripts/install_new.sh /install.sh
 COPY --from=downloader /tmp/ /tmp/
@@ -89,15 +89,15 @@ COPY --from=installer /opt/1cv8 /opt/1cv8
 COPY --from=installer /bin/gosu /bin/gosu
 RUN set -xe \
   && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      locales \
-      iproute2 \
-      imagemagick \
-      fontconfig \
-      ca-certificates \
+  && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+    ca-certificates \
+    fontconfig \
+    imagemagick \
+    iproute2 \
+    locales \
   && rm -rf /var/lib/apt/lists/* /var/cache/debconf \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
-ENV LANG ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
 
 # Настройка группы и пользователя
 RUN groupadd -r grp1cv8 --gid=$onec_gid \
@@ -115,7 +115,8 @@ COPY ./server/logcfg.xml /opt/1cv8/current/conf
 COPY ./server/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN ln -s usr/local/bin/docker-entrypoint.sh /  # backwards compat
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh 
-RUN apt-get update && apt-get install -yq procps
+RUN apt-get update && apt-get install --yes --quiet procps \
+  && rm -rf /var/lib/apt/lists/* /var/cache/debconf
 RUN chmod +x /opt/1cv8/current/ragent
 
 # Настройка точки входа и экспонирование портов

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -50,6 +50,9 @@ main() {
     setup_ragent_cmd
     setup_ras_cmd
 
+    # Добавляем каталог с исполняемыми файлами 1С в PATH
+    PATH="/opt/1cv8/current:$PATH"
+
     echo "Запускаем ras с необходимыми параметрами"
     echo "Выполняемая команда: $RAS_CMD"
     $RAS_CMD 2>&1 &  # Запуск ras в фоновом режиме

--- a/swarm-jenkins-agent/Dockerfile
+++ b/swarm-jenkins-agent/Dockerfile
@@ -23,7 +23,7 @@ RUN set -xe \
     /var/cache/debconf \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 
-ENV LANG ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
 
 COPY ./swarm-jenkins-agent/docker-entrypoint.sh /
 RUN chmod 755 /docker-entrypoint.sh \

--- a/thin-client/Dockerfile
+++ b/thin-client/Dockerfile
@@ -2,7 +2,7 @@
 ARG DOCKER_REGISTRY_URL
 ARG BASE_IMAGE
 ARG BASE_TAG
-FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG} as downloader
+FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG} AS downloader
 
 # Копирование скрипта скачивания и локальных дистрибутивов
 COPY ./scripts/download_yard.sh /download.sh
@@ -18,23 +18,23 @@ WORKDIR /tmp
 
 # Установка необходимых пакетов и генерация локали
 RUN apt-get update \
-  && apt-get install -y \
-          locales \
-          p7zip-rar \
-          p7zip-full \
+  && apt-get install --yes \
+    locales \
+    p7zip-full \
+    p7zip-rar \
   && rm -rf /var/lib/apt/lists/* \
   && locale-gen ru_RU.UTF-8 \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 
 # Установка переменных окружения для корректной работы локали
-ENV LANG ru_RU.UTF-8
-ENV LANGUAGE ru_RU:ru
-ENV LC_ALL ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
+ENV LANGUAGE=ru_RU:ru
+ENV LC_ALL=ru_RU.UTF-8
 
 RUN /download.sh "$ONEC_USERNAME" "$ONEC_PASSWORD" "$ONEC_VERSION" "thin-client"
 
 # Начало основной стадии сборки
-FROM ubuntu:18.04 as base
+FROM ubuntu:18.04 AS base
 
 # Копируем скрипты и файлы установки
 ARG ONEC_VERSION
@@ -93,7 +93,7 @@ RUN set -xe \
     /var/lib/apt/lists/* \
     /var/cache/debconf \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
-ENV LANG ru_RU.UTF-8
+ENV LANG=ru_RU.UTF-8
 
 RUN groupadd -r grp1cv8 --gid=$onec_gid \
   && useradd -r -g grp1cv8 --uid=$onec_uid --home-dir=/home/usr1cv8 --shell=/bin/bash usr1cv8 \


### PR DESCRIPTION
Для сокращения путей при запуске. напр:
docker run --rm -it localhost:5000/onec-server:8.3.25.1546 ibcmd --version

В моём случае ещё и для совместимости при "переезде".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced several PowerShell scripts to automate the building and pushing of Docker images for various components, improving deployment efficiency.
  - Added a new entrypoint script for the client, enhancing application startup processes.
  - New configuration properties added for the PUSK application, providing detailed logging and security settings.
  - Added a new PowerShell script `build-crs-apache.ps1` to automate Docker image building for the CRS Apache server.
  - Added a new PowerShell script `build-pusk.ps1` for loading environment variables and performing Docker operations for the PUSK project.

- **Chores**
  - Enhanced the runtime environment by including an additional directory for utilities, enabling smoother and more efficient command execution without manual path specifications.
  - Updated Dockerfiles across various components to streamline installation processes and improve readability.
  - Modified configuration files to reflect updated directory structures and access paths for the web server.
  - Expanded end-of-line handling in `.gitattributes` for additional directories, ensuring consistent file formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->