### PR TITLE
Затирается русская локаль в итоговом образе

### DIFF
--- a/oscript/Dockerfile
+++ b/oscript/Dockerfile
@@ -7,9 +7,6 @@ FROM ${DOCKER_REGISTRY_URL}/${BASE_IMAGE}:${BASE_TAG}
 # Installing mono and oscript dependencies
 ARG MONO_VERSION=6.12.0.122
 
-ENV LANG="C.UTF-8" \
-    LC_ALL="C.UTF-8"
-
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       ca-certificates \


### PR DESCRIPTION
Случается такая ситуация, когда база создается ровно в той локали, которая была прописана при сборке образа

![image](https://github.com/user-attachments/assets/5904f871-85ec-49a3-9406-29461f98adc0)

НО. Если нужно будет наоборот создать базу с английской локалью, то видимо это исправление так же не даст создать базу.

Вообще выглядит как косяк платформы при создании базы, когда она не применяет переданные параметры локали.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the container configuration by removing redundant locale settings to streamline the runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->