### PR TITLE
Уменьшил размер образа EDT в 2 раза

### DIFF
--- a/edt/Dockerfile
+++ b/edt/Dockerfile
@@ -38,6 +38,43 @@ ENV LC_ALL ru_RU.UTF-8
 
 RUN /download.sh "$ONEC_USERNAME" "$ONEC_PASSWORD" "$EDT_VERSION" "edt"
 
+FROM ${BASE_IMAGE}:${BASE_TAG} as installer
+
+LABEL maintainer="Nikita Gryzlov <NikGryzlov@1bit.com>, FirstBit"
+
+ARG EDT_VERSION=2021.3
+ARG downloads=downloads/DevelopmentTools10/${EDT_VERSION}
+
+WORKDIR /tmp
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    # downloader dependencies
+    curl \
+    # edt dependencies
+    libgtk-3-0 \
+    locales \
+  && cd / \
+  && rm -rf  \
+    /var/lib/apt/lists/* \
+    /var/cache/debconf \
+    /tmp/* \
+  && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
+
+# Install EDT
+COPY --from=downloader /tmp/${downloads} /tmp/${downloads}
+
+WORKDIR /tmp/${downloads}
+
+RUN chmod +x ./1ce-installer-cli \
+  && ./1ce-installer-cli install all --ignore-hardware-checks --ignore-signature-warnings\
+  && mv $(dirname $(find /opt/1C/1CE -name ring)) /opt/1C/1CE/components/1c-enterprise-ring \
+  #1cedtcli отсутствует в EDT версии <2023.1.0
+  && if [ -n "$(find /opt/1C/1CE -name 1cedtcli)" ]; then mv $(dirname $(find /opt/1C/1CE -name 1cedtcli)) /opt/1C/1CE/components/1cedtcli; fi \
+  && cd / \
+  && rm -rf \
+    /tmp/*
+
 FROM ${BASE_IMAGE}:${BASE_TAG}
 
 LABEL maintainer="Nikita Gryzlov <NikGryzlov@1bit.com>, FirstBit"
@@ -57,24 +94,12 @@ RUN apt-get update \
     /tmp/* \
   && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
 
-ARG EDT_VERSION=2021.3
-ARG downloads=downloads/DevelopmentTools10/${EDT_VERSION}
-
 # Установка переменных окружения для корректной работы локали
 ENV LANG ru_RU.UTF-8
 ENV LANGUAGE ru_RU:ru
 ENV LC_ALL ru_RU.UTF-8
 
-# Install EDT
-COPY --from=downloader /tmp/${downloads} /tmp/${downloads}
-
-WORKDIR /tmp/${downloads}
-
-RUN chmod +x ./1ce-installer-cli \
-  && ./1ce-installer-cli install all --ignore-hardware-checks --ignore-signature-warnings\
-  && rm -rf /tmp/* \
-  && mv $(dirname $(find /opt/1C/1CE -name ring)) /opt/1C/1CE/components/1c-enterprise-ring \
-  #1cedtcli отсутствует в EDT версии <2023.1.0
-  && if [ -n "$(find /opt/1C/1CE -name 1cedtcli)" ]; then mv $(dirname $(find /opt/1C/1CE -name 1cedtcli)) /opt/1C/1CE/components/1cedtcli; fi
+# Copy EDT
+COPY --from=installer /opt/1C/1CE /opt/1C/1CE
 
 ENV PATH="/opt/1C/1CE/components/1c-enterprise-ring:/opt/1C/1CE/components/1cedtcli:$PATH"

--- a/edt/Dockerfile
+++ b/edt/Dockerfile
@@ -54,7 +54,6 @@ RUN apt-get update \
     # edt dependencies
     libgtk-3-0 \
     locales \
-  && cd / \
   && rm -rf  \
     /var/lib/apt/lists/* \
     /var/cache/debconf \
@@ -71,7 +70,6 @@ RUN chmod +x ./1ce-installer-cli \
   && mv $(dirname $(find /opt/1C/1CE -name ring)) /opt/1C/1CE/components/1c-enterprise-ring \
   #1cedtcli отсутствует в EDT версии <2023.1.0
   && if [ -n "$(find /opt/1C/1CE -name 1cedtcli)" ]; then mv $(dirname $(find /opt/1C/1CE -name 1cedtcli)) /opt/1C/1CE/components/1cedtcli; fi \
-  && cd / \
   && rm -rf \
     /tmp/*
 


### PR DESCRIPTION
Добавил еще один stage (installer), чтобы в итоговом образе не хранился дистрибутив EDT.
Результат - примерно двукратное уменьшение размера образа.

Проверил на EDT 2024.1.3, все операции работают.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the container image build process with a streamlined, multi-phase approach separating installation from final configuration.
  - Refined environment settings and cleanup steps to ensure a more efficient and maintainable build workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->