### PR TITLE
Добавил для клиента библиотеку libglu1-mesa

### DIFF
--- a/client-vnc/Dockerfile
+++ b/client-vnc/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
       procps \
       x11vnc \
       iproute2 \
+      libglu1-mesa \
   # Install libpng12-0 from xenial
   && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 40976EAF437D05B5 \
   && echo "deb http://security.ubuntu.com/ubuntu xenial-security main" > /etc/apt/sources.list.d/xenial-security.list \

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -91,6 +91,7 @@ RUN set -xe \
       libodbc1 \
       libmagickwand-6.q16-3 \
       dbus-x11 \
+      libglu1-mesa \
   && rm -rf  \
     /var/lib/apt/lists/* \
     /var/cache/debconf \


### PR DESCRIPTION
Исправил ошибку для платформы 8.3.27.1508, при которой клиент не мог запуститься.
```
01:54:41  + vrunner update-dev --src /var/jenkins_home/workspace/wms-lite_382/build/cfg --ibconnection /F./build/ib
01:54:42  vanessa-runner v2.5.0
01:54:42  ИНФОРМАЦИЯ - Используется версия платформы 8.3.27.1508
01:54:42  ИНФОРМАЦИЯ - Запускаем обновление конфигурации из исходников...
01:54:42  ИНФОРМАЦИЯ - Загрузка конфигурации из файлов /var/jenkins_home/workspace/wms-lite_382/build/cfg
01:54:42  ОШИБКА - /opt/1cv8/x86_64/8.3.27.1508/1cv8: error while loading shared libraries: libGLU.so.1: cannot open shared object file: No such file or directory
01:54:42  ОШИБКА - Получен ненулевой код возврата 127. Выполнение скрипта остановлено!
01:54:42  КРИТИЧНАЯОШИБКА - {Модуль /root/.local/share/ovm/stable/lib/vanessa-runner/oscript_modules/v8runner/src/v8runner.os / Ошибка в строке: 1548 / Информации об ошибке нет}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated system dependencies to include additional graphical library support for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->