### PR TITLE
Убрал лишние pull, исправил форматирование

### DIFF
--- a/build-base-swarm-jenkins-agent.bat
+++ b/build-base-swarm-jenkins-agent.bat
@@ -11,26 +11,25 @@ if %ERRORLEVEL% neq 0 goto end
 if %NO_CACHE%=="true" (SET last_arg="--no-cache .") else (SET last_arg=".")
 
 docker build ^
-	--pull ^
-	--build-arg DOCKER_REGISTRY_URL=library ^
+    --pull ^
+    --build-arg DOCKER_REGISTRY_URL=library ^
     --build-arg BASE_IMAGE=ubuntu ^
     --build-arg BASE_TAG=20.04 ^
     --build-arg ONESCRIPT_PACKAGES="yard" ^
     -t %DOCKER_REGISTRY_URL%/oscript-downloader:latest ^
-	-f oscript/Dockerfile ^
+    -f oscript/Dockerfile ^
     %last_arg%
 
 docker build ^
-	--pull ^
-	--build-arg ONEC_USERNAME=%ONEC_USERNAME% ^
-	--build-arg ONEC_PASSWORD=%ONEC_PASSWORD% ^
-	--build-arg ONEC_VERSION=%ONEC_VERSION% ^
-	--build-arg DOCKER_REGISTRY_URL=%DOCKER_REGISTRY_URL% ^
+    --build-arg ONEC_USERNAME=%ONEC_USERNAME% ^
+    --build-arg ONEC_PASSWORD=%ONEC_PASSWORD% ^
+    --build-arg ONEC_VERSION=%ONEC_VERSION% ^
+    --build-arg DOCKER_REGISTRY_URL=%DOCKER_REGISTRY_URL% ^
     --build-arg BASE_IMAGE=oscript-downloader ^
     --build-arg BASE_TAG=latest ^
-	-t %DOCKER_REGISTRY_URL%/onec-client:%ONEC_VERSION% ^
-	-f client/Dockerfile ^
-	%last_arg%
+    -t %DOCKER_REGISTRY_URL%/onec-client:%ONEC_VERSION% ^
+    -f client/Dockerfile ^
+    %last_arg%
 
 if %ERRORLEVEL% neq 0 goto end
 
@@ -39,14 +38,13 @@ docker push %DOCKER_REGISTRY_URL%/onec-client:%ONEC_VERSION%
 if %ERRORLEVEL% neq 0 goto end
 
 docker build ^
-	--pull ^
-	--build-arg ONEC_USERNAME=%ONEC_USERNAME% ^
-	--build-arg ONEC_PASSWORD=%ONEC_PASSWORD% ^
-	--build-arg ONEC_VERSION=%ONEC_VERSION% ^
-	--build-arg DOCKER_REGISTRY_URL=%DOCKER_REGISTRY_URL% ^
-	-t %DOCKER_REGISTRY_URL%/onec-client-vnc:%ONEC_VERSION% ^
-	-f client-vnc/Dockerfile ^
-	%last_arg%
+    --build-arg ONEC_USERNAME=%ONEC_USERNAME% ^
+    --build-arg ONEC_PASSWORD=%ONEC_PASSWORD% ^
+    --build-arg ONEC_VERSION=%ONEC_VERSION% ^
+    --build-arg DOCKER_REGISTRY_URL=%DOCKER_REGISTRY_URL% ^
+    -t %DOCKER_REGISTRY_URL%/onec-client-vnc:%ONEC_VERSION% ^
+    -f client-vnc/Dockerfile ^
+    %last_arg%
 
 if %ERRORLEVEL% neq 0 goto end
 
@@ -55,7 +53,7 @@ docker push %DOCKER_REGISTRY_URL%/onec-client-vnc:%ONEC_VERSION%
 if %ERRORLEVEL% neq 0 goto end
 
 docker build ^
-	--build-arg DOCKER_REGISTRY_URL=%DOCKER_REGISTRY_URL% ^
+    --build-arg DOCKER_REGISTRY_URL=%DOCKER_REGISTRY_URL% ^
     --build-arg BASE_IMAGE=onec-client-vnc ^
     --build-arg BASE_TAG=%ONEC_VERSION% ^
     -t %DOCKER_REGISTRY_URL%/onec-client-vnc-oscript:%ONEC_VERSION% ^

--- a/build-base-swarm-jenkins-agent.sh
+++ b/build-base-swarm-jenkins-agent.sh
@@ -20,14 +20,14 @@ if [ "${NO_CACHE}" = 'true' ] ; then
 fi
 
 docker build \
-	--pull \
+    --pull \
     $no_cache_arg \
-	--build-arg DOCKER_REGISTRY_URL=library \
+    --build-arg DOCKER_REGISTRY_URL=library \
     --build-arg BASE_IMAGE=ubuntu \
     --build-arg BASE_TAG=20.04 \
     --build-arg ONESCRIPT_PACKAGES="yard" \
     -t ${DOCKER_REGISTRY_URL:+"$DOCKER_REGISTRY_URL/"}oscript-downloader:latest \
-	-f oscript/Dockerfile \
+    -f oscript/Dockerfile \
     $last_arg
 
 docker build \
@@ -48,7 +48,6 @@ else
 fi
 
 docker build \
-    --pull \
     --build-arg ONEC_USERNAME=$ONEC_USERNAME \
     --build-arg ONEC_PASSWORD=$ONEC_PASSWORD \
     --build-arg ONEC_VERSION=$ONEC_VERSION \

--- a/build-oscript-swarm-agent.bat
+++ b/build-oscript-swarm-agent.bat
@@ -11,8 +11,8 @@ if %ERRORLEVEL% neq 0 goto end
 if %NO_CACHE%=="true" (SET last_arg="--no-cache .") else (SET last_arg=".")
 
 docker build ^
-	--pull ^
-	--build-arg DOCKER_REGISTRY_URL=library ^
+    --pull ^
+    --build-arg DOCKER_REGISTRY_URL=library ^
     --build-arg BASE_IMAGE=eclipse-temurin ^
     --build-arg BASE_TAG=17 ^
     -t %DOCKER_REGISTRY_URL%/oscript-jdk:latest ^

--- a/build-oscript-swarm-agent.sh
+++ b/build-oscript-swarm-agent.sh
@@ -20,13 +20,13 @@ if [ "${NO_CACHE}" = 'true' ] ; then
 fi
 
 docker build \
-	--pull \
+    --pull \
     $no_cache_arg \
-	--build-arg DOCKER_REGISTRY_URL=library \
+    --build-arg DOCKER_REGISTRY_URL=library \
     --build-arg BASE_IMAGE=eclipse-temurin \
     --build-arg BASE_TAG=17 \
     -t ${DOCKER_REGISTRY_URL:+"$DOCKER_REGISTRY_URL/"}oscript-jdk:latest \
-	-f oscript/Dockerfile \
+    -f oscript/Dockerfile \
     $last_arg
 
 docker build \


### PR DESCRIPTION
@nixel2007 решил убрать флаги --pull, потому что это мешает сборке без Registry (как обсуждали).

Насколько я понимаю, что даже если сборка идет с использованием Registry, то свежий образ и так уже есть локально.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated whitespace and indentation formatting in build scripts for consistency.

* **Chores**
  * Modified Docker image pull behavior by removing the --pull flag from select build steps across multiple build scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->