### PR TITLE
Изменения для запуска EDT 2025.2.3 и платформы 8.3.27.1989

### DIFF
--- a/build-edt.sh
+++ b/build-edt.sh
@@ -15,12 +15,14 @@ if [ "${DOCKER_SYSTEM_PRUNE}" = 'true' ] ; then
 fi
 
 #Если версия EDT >= 2024.1.0, использовать JDK 17
-if [[ "$(printf "%s\n" "$EDT_VERSION" "2024" | sort -V | head -n 1)" == "2024" ]]; then
-  BASE_IMAGE="azul/zulu-openjdk"
-  BASE_TAG="17"
+if [[ "$EDT_VERSION" == 2024* ]] || [[ "$EDT_VERSION" == 2025* ]]; then
+  # Для новых версий используем Ubuntu + Java 17
+  # (Это надежнее, чем просто голая Java-платформа)
+  BASE_IMAGE="eclipse-temurin"
+  BASE_TAG="17-jdk-jammy" 
 else
   BASE_IMAGE="eclipse-temurin"
-  BASE_TAG="11"
+  BASE_TAG="11-jdk-focal"
 fi
 
 last_arg='.'

--- a/client-vnc/Dockerfile
+++ b/client-vnc/Dockerfile
@@ -9,6 +9,9 @@ LABEL maintainer="Dima Ovcharenko <d.ovcharenko90@gmail.com>, Korus Consulting L
 
 USER root
 
+# FIX: remove old libstdc++ shipped with 1C (causes GLIBCXX errors)
+RUN find /opt/1cv8 -name "libstdc++.so*" -delete
+
 RUN apt-get update \
   && apt-mark hold iptables \
   && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -39,6 +42,9 @@ RUN apt-get update \
 
 # Disable accessibility
 ENV NO_AT_BRIDGE=1
+
+# Fix WebKit / GTK issues in containers
+ENV QT_X11_NO_MITSHM=1
 
 # Disable session manager
 ENV XDG_SESSION_TYPE=x11

--- a/edt/Dockerfile
+++ b/edt/Dockerfile
@@ -3,8 +3,9 @@ ARG DOWNLOADER_REGISTRY_URL
 ARG DOWNLOADER_IMAGE
 ARG DOWNLOADER_TAG
 
+# Для EDT 2025.x ОБЯЗАТЕЛЬНО используем Java 17
 ARG BASE_IMAGE=eclipse-temurin
-ARG BASE_TAG=11
+ARG BASE_TAG=17-jdk-jammy
 ARG DOCKER_REGISTRY_URL
 
 FROM ${DOWNLOADER_REGISTRY_URL:+"$DOWNLOADER_REGISTRY_URL/"}${DOWNLOADER_IMAGE}:${DOWNLOADER_TAG} AS downloader
@@ -53,26 +54,31 @@ RUN apt-get update \
     # edt dependencies
     libgtk-3-0 \
     locales \
+    libc-bin \
+    coreutils \
   && rm -rf  \
     /var/lib/apt/lists/* \
     /var/cache/debconf \
     /tmp/* \
-  && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8
+  && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8 \
+  && echo '#!/bin/sh\nif [ "$1" = "LONG_BIT" ]; then echo "64"; else echo "unknown"; fi' > /usr/local/bin/getconf \
+  && chmod +x /usr/local/bin/getconf
 
 # Install EDT
 COPY --from=downloader /tmp/${downloads} /tmp/${downloads}
 
 WORKDIR /tmp/${downloads}
 
-RUN chmod +x ./1ce-installer-cli \
-  && ./1ce-installer-cli install all --ignore-hardware-checks --ignore-signature-warnings\
+RUN chmod -R +x . \
+  && ./1ce-installer-cli install all --ignore-hardware-checks --ignore-signature-warnings \
   && ln -s $(dirname $(find /opt/1C/1CE -name ring)) /opt/1C/1CE/components/1c-enterprise-ring \
   #1cedtcli отсутствует в EDT версии <2023.1.0
   && if [ -n "$(find /opt/1C/1CE -name 1cedtcli)" ]; then ln -s $(dirname $(find /opt/1C/1CE -name 1cedtcli)) /opt/1C/1CE/components/1cedtcli; fi \
   && rm -rf \
     /tmp/* \
   # создадим пустой файл, чтобы не было ошибок на следуюших этапах в случае его отсутствия
-  && if [ ! -f /etc/1C/1CE/ring-commands.cfg ]; then touch /etc/1C/1CE/ring-commands.cfg; fi
+  && if [ ! -f /etc/1C/1CE/ring-commands.cfg ]; then touch /etc/1C/1CE/ring-commands.cfg; fi \
+  && rm /usr/local/bin/getconf
 
 FROM ${BASE_IMAGE}:${BASE_TAG}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential runtime symbol errors in the VNC client caused by incompatible system libraries.

* **Improvements**
  * Java 17 is now the default for EDT 2025.x to ensure compatibility.
  * Improved installer robustness and updated runtime dependencies.
  * Added build-time cleanup and environment tweaks to improve X11/Qt display reliability in containerized environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->