### PR TITLE
Добавил кавычки в скрипты сборки test-utils

### DIFF
--- a/build-base-k8s-jenkins-agent.sh
+++ b/build-base-k8s-jenkins-agent.sh
@@ -97,7 +97,7 @@ docker build \
     --build-arg DOCKER_REGISTRY_URL=$DOCKER_REGISTRY_URL \
     --build-arg BASE_IMAGE=onec-client-vnc-oscript-jdk \
     --build-arg BASE_TAG=$ONEC_VERSION \
-    --build-arg TEST_UTILS_EXTRA_PACKAGES=$TEST_UTILS_EXTRA_PACKAGES \
+    --build-arg "TEST_UTILS_EXTRA_PACKAGES=$TEST_UTILS_EXTRA_PACKAGES" \
     -t ${DOCKER_REGISTRY_URL:+"$DOCKER_REGISTRY_URL/"}onec-client-vnc-oscript-jdk-testutils:$ONEC_VERSION \
     -f test-utils/Dockerfile \
     $last_arg

--- a/build-base-swarm-jenkins-agent.bat
+++ b/build-base-swarm-jenkins-agent.bat
@@ -78,7 +78,7 @@ docker build ^
     --build-arg DOCKER_REGISTRY_URL=%DOCKER_REGISTRY_URL% ^
     --build-arg BASE_IMAGE=onec-client-vnc-oscript-jdk ^
     --build-arg BASE_TAG=%ONEC_VERSION% ^
-    --build-arg TEST_UTILS_EXTRA_PACKAGES=%TEST_UTILS_EXTRA_PACKAGES% ^
+    --build-arg "TEST_UTILS_EXTRA_PACKAGES=%TEST_UTILS_EXTRA_PACKAGES%" ^
     -t %DOCKER_REGISTRY_URL%/onec-client-vnc-oscript-jdk-testutils:%ONEC_VERSION% ^
     -f test-utils/Dockerfile ^
     %last_arg%

--- a/build-base-swarm-jenkins-agent.sh
+++ b/build-base-swarm-jenkins-agent.sh
@@ -96,7 +96,7 @@ docker build \
     --build-arg DOCKER_REGISTRY_URL=$DOCKER_REGISTRY_URL \
     --build-arg BASE_IMAGE=onec-client-vnc-oscript-jdk \
     --build-arg BASE_TAG=$ONEC_VERSION \
-    --build-arg TEST_UTILS_EXTRA_PACKAGES=$TEST_UTILS_EXTRA_PACKAGES \
+    --build-arg "TEST_UTILS_EXTRA_PACKAGES=$TEST_UTILS_EXTRA_PACKAGES" \
     -t ${DOCKER_REGISTRY_URL:+"$DOCKER_REGISTRY_URL/"}onec-client-vnc-oscript-jdk-testutils:$ONEC_VERSION \
     -f test-utils/Dockerfile \
     $last_arg


### PR DESCRIPTION
Если новая переменная TEST_UTILS_EXTRA_PACKAGES содержит пробел, это ломает команду docker build.

Я заключил ее в кавычки в имеющихся скриптах.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build argument handling in build scripts to ensure proper parsing of package configurations containing special characters or whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->