### PR TITLE
Поддержка скачивания и установки платформы 8.5

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -39,8 +39,8 @@ FROM ubuntu:20.04 AS base
 ARG ONEC_VERSION
 ARG gosu_ver=1.11
 ARG nls_enabled=false
+
 ENV nls=$nls_enabled
-ENV distrPath=/tmp/downloads/Platform83/${ONEC_VERSION}
 ENV installer_type=client
 
 # Установка gnupg и wget
@@ -85,7 +85,6 @@ RUN set -e \
 
 COPY --chmod=755 ./scripts/install_new.sh /install.sh
 COPY --from=downloader /tmp/ /tmp/
-WORKDIR ${distrPath}      
 
 SHELL ["/bin/bash", "-c"]
 RUN ls . \

--- a/edt/Dockerfile
+++ b/edt/Dockerfile
@@ -44,8 +44,6 @@ LABEL maintainer="Nikita Gryzlov <NikGryzlov@1bit.com>, FirstBit"
 ARG EDT_VERSION=2021.3
 ARG downloads=downloads/DevelopmentTools10/${EDT_VERSION}
 
-WORKDIR /tmp
-
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     # downloader dependencies

--- a/scripts/download_yard.sh
+++ b/scripts/download_yard.sh
@@ -8,12 +8,13 @@ installer_type=$4
 
 if [ "$installer_type" = "edt" ]; then
     FOLDER_NAME="DevelopmentTools10"
+    DOWNLOADS_PATH=/tmp/downloads/${FOLDER_NAME}/${EDT_VERSION}
 else
-    FOLDER_NAME="Platform83"
+    ONEC_MAJOR_VER=$(echo "$ONEC_VERSION" | cut -d'.' -f1,2 | tr -d '.')
+
+    FOLDER_NAME="Platform${ONEC_MAJOR_VER}"
+    DOWNLOADS_PATH=/tmp/downloads/${FOLDER_NAME}/${ONEC_VERSION}
 fi
-
-DOWNLOADS_PATH=/tmp/downloads/${FOLDER_NAME}/${ONEC_VERSION}
-
 
 # Преобразование версии для различных целей
 ONEC_VERSION_DOTS=$ONEC_VERSION
@@ -136,6 +137,8 @@ download_distr() {
 # Функция проверки наличия нужных файлов после распаковки
 check_file() {
   found=1
+  echo "Содержимое каталога $DOWNLOADS_PATH:"
+  ls -l $DOWNLOADS_PATH
   # Проверяем, появились ли файлы в каталоге
     if [ "$installer_type" = "edt" ]; then
         # Для edt проверяем наличие специфичного файла
@@ -144,8 +147,6 @@ check_file() {
             found=0
         else
             echo "Не найден файл 1ce-installer-cli"
-            echo "Содержимое каталога $DOWNLOADS_PATH:"
-            ls -l $DOWNLOADS_PATH 
         fi
     elif ls $DOWNLOADS_PATH/*.deb 1> /dev/null 2>&1 || ls $DOWNLOADS_PATH/*.run 1> /dev/null 2>&1; then
         echo "Дистрибутив найден и скачан: $filter"
@@ -160,7 +161,7 @@ check_file() {
 try_download() {
 
   # Определим фильтры для скачивания. Если шаблонов >1 они должны разделяться "|" Скачивается дистрибутив по первому найденному шаблону.
-  APP_FILTER="Технологическая платформа *8\.3"
+  APP_FILTER="Технологическая платформа *8\.[3,5]"
   case "$installer_type" in
     edt)
         echo "Скачиваем дистрибутив EDT"
@@ -223,7 +224,7 @@ if [ $local_distr_found -ne 0 ]; then
     echo "Ошибка: Скачивание версии 8.3.24.1342 и 8.3.24.1368 не поддерживается. Скачайте и распакуйте релиз самостоятельно, и поместите его в папку distr"
     exit 1
   else
-    echo "Версия 1с: $ONEC_VERSION" 
+    echo "Версия 1с: $ONEC_VERSION"
   fi
   try_download
   download_attempted=$?

--- a/scripts/install_new.sh
+++ b/scripts/install_new.sh
@@ -17,7 +17,7 @@ install_from_deb() {
         else
             dpkg -i "1c-enterprise*-{common,server,ws,crs}_*.deb"
         fi
-      ;;  
+      ;;
       client)
         if [ "$nls" = true ]; then
             dpkg -i "1c-enterprise*-{common,server,client}*.deb"
@@ -27,9 +27,9 @@ install_from_deb() {
         ;;
       thin-client)
         if [ "$nls" = true ]; then
-            dpkg -i "1c-enterprise83-thin-client*.deb"
+            dpkg -i "1c-enterprise*-thin-client*.deb"
         else
-            dpkg -i "1c-enterprise83-thin-client_*.deb"
+            dpkg -i "1c-enterprise*-thin-client_*.deb"
         fi
         ;;
     esac
@@ -46,7 +46,7 @@ install_from_run() {
 
     chmod +x "$run_file"
 
-    if [ "$nls" = true ]; then 
+    if [ "$nls" = true ]; then
       nls_install="az,ar,hy,bg,hu,el,vi,ka,kk,zh,it,es,lv,lt,de,pl,ro,ru,tr,tk,fr,uk"
     else
       nls_install="ru"
@@ -56,7 +56,7 @@ install_from_run() {
       server)
         run_components="server,ws,config_storage_server,$nls_install"
         ;;
-      server_crs) 
+      server_crs)
         run_components="server,ws,config_storage_server,$nls_install"
         ;;
       client)
@@ -80,6 +80,10 @@ install_from_run() {
         exit 1
     fi
 }
+
+ONEC_MAJOR_VER=$(echo "$ONEC_VERSION" | cut -d'.' -f1,2 | tr -d '.')
+
+cd /tmp/downloads/Platform${ONEC_MAJOR_VER}/${ONEC_VERSION}
 
 # Определяем, есть ли .deb файлы
 if ls *.deb 1> /dev/null 2>&1; then


### PR DESCRIPTION
Доработал скрипты таким образом, что теперь успешно скачивается и устанавливается платформа 8.5.

По пути немного упростил логику, например, удалил переменную distrPath и связанную с ней команду WORKDIR.

Из минусов: путь к каталогу с дистрибутивами определяется в двух местах: в скрипте скачивания и в скрипте установки. Я не нашел красивого способа рассчитать его один раз и использовать дальше в сборке.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured installation path handling to support multiple 1C Enterprise versions dynamically
  * Enhanced version compatibility for downloads, now supporting versions 8.3 and 8.5
  * Simplified Docker configuration for improved container build consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->